### PR TITLE
Add Inbound Offset automation

### DIFF
--- a/gui/forms.py
+++ b/gui/forms.py
@@ -73,6 +73,8 @@ class GUIForm(AutoFeesForm):
 class LocalSettingsForm(GUIForm):
     lnd_cleanPayments = forms.IntegerField(label='lnd_cleanPayments', required=False)
     lnd_retentionDays = forms.IntegerField(label='lnd_retentionDays', required=False)
+    io_enabled = forms.IntegerField(label='io_enabled', required=False)
+    io_updateHours = forms.FloatField(label='io_updateHours', required=False)
 
 updates_channel_codes = [
     (0, 'base_fee'),
@@ -145,3 +147,8 @@ class BatchOpenForm(forms.Form):
     pubkey10 = forms.CharField(label='pubkey10', max_length=66, required=False)
     amt10 = forms.IntegerField(label='amt10', required=False)
     fee_rate = forms.IntegerField(label='fee_rate')
+
+class InboundOffsetForm(forms.Form):
+    chan_id = forms.IntegerField(label='chan_id')
+    offset = forms.IntegerField(label='offset')
+

--- a/gui/migrations/0045_channels_inbound_offset.py
+++ b/gui/migrations/0045_channels_inbound_offset.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gui', '0044_indexes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channels',
+            name='inbound_offset',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='offset_updated',
+            field=models.DateTimeField(null=True, default=None),
+        ),
+    ]

--- a/gui/models.py
+++ b/gui/models.py
@@ -105,6 +105,8 @@ class Channels(models.Model):
     local_fee_rate = models.IntegerField()
     local_inbound_base_fee = models.IntegerField()
     local_inbound_fee_rate = models.IntegerField()
+    inbound_offset = models.IntegerField(default=0)
+    offset_updated = models.DateTimeField(null=True, default=None)
     local_disabled = models.BooleanField()
     local_cltv = models.IntegerField()
     local_min_htlc_msat = models.BigIntegerField()

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -144,6 +144,7 @@
   <a class="w3-bar-item w3-hover-blue" href="/peerevents" target="_blank">Peer Events</a>
   <a class="w3-bar-item w3-hover-blue" href="/actions" target="_blank">AR Actions</a> 
   <a class="w3-bar-item w3-hover-blue" href="/fees" target="_blank">Fee Rates</a>
+  <a class="w3-bar-item w3-hover-blue" href="/inbound-offset" target="_blank">Inbound Offset</a>
   <a class="w3-bar-item w3-hover-blue" href="/autopilot" target="_blank">Autopilot</a>
   <a class="w3-bar-item w3-hover-blue" href="/autofees" target="_blank">Outbound Fee Log</a>
   <a class="w3-bar-item w3-hover-blue" href="/inbound-fee-log" target="_blank">Inbound Fee Log</a>

--- a/gui/templates/inbound_offset.html
+++ b/gui/templates/inbound_offset.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %} {{ block.super }} - Inbound Offset{% endblock %}
+{% block content %}
+{% load humanize %}
+{% if channels %}
+<div class="w3-container w3-padding-small">
+  <h2>Inbound Offset</h2>
+  <div class="w3-container w3-padding-small" style="overflow-x: scroll">
+    <table class="w3-table-all w3-centered w3-hoverable">
+      <tr>
+        <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
+        <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
+        <th onclick="sortTable(event.target, 2, 'int')">Outbound PPM</th>
+        <th>Inbound Offset</th>
+      </tr>
+      {% for channel in channels %}
+      <tr>
+        <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
+        <td title="{{ channel.remote_pubkey }}">{% if channel.private == False %}<a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% endif %}{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}{% if channel.private == False %}</a>{% endif %}</td>
+        <td>{{ channel.local_fee_rate|intcomma }}</td>
+        <td>
+          <form action="/inbound-offset/" method="post">
+            {% csrf_token %}
+            <input style="text-align:center" type="number" min="-100000" max="0" name="offset" value="{{ channel.inbound_offset|default:0 }}">
+            <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>
+{% else %}
+<div class="w3-container w3-padding-small">
+  <center><h1>You dont have any channels to analyze yet!</h1></center>
+</div>
+{% endif %}
+{% if local_settings %}
+{% include 'local_settings.html' with settings=local_settings title='Inbound Offset' %}
+{% endif %}
+{% endblock %}

--- a/gui/templates/local_settings.html
+++ b/gui/templates/local_settings.html
@@ -17,6 +17,7 @@
           <div class="w3-col input" data-unit="{{sett.unit}}">
             <input class="w3-col" id="{{sett.form_id}}" name="{{sett.form_id}}" {% if sett.min %}min="{{sett.min}}" step="{{sett.min}}"{% endif %} {% if sett.max %}max="{{sett.max}}" type="number"{% endif %} value="{{sett.value}}"/>
             {% if sett.form_id == 'af_updateHours' %}<small id="af_updateMinutes"></small>{% endif %}
+            {% if sett.form_id == 'io_updateHours' %}<small id="io_updateMinutes"></small>{% endif %}
           </div>
           {% endif %}
         </div>
@@ -35,15 +36,25 @@
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const input = document.getElementById('af_updateHours');
-    const label = document.getElementById('af_updateMinutes');
-    if (input && label) {
+    const afInput = document.getElementById('af_updateHours');
+    const afLabel = document.getElementById('af_updateMinutes');
+    if (afInput && afLabel) {
       function showMinutes() {
-        const val = parseFloat(input.value);
-        label.textContent = isNaN(val) ? '' : `(${Math.round(val * 60)} min)`;
+        const val = parseFloat(afInput.value);
+        afLabel.textContent = isNaN(val) ? '' : `(${Math.round(val * 60)} min)`;
       }
-      input.addEventListener('input', showMinutes);
+      afInput.addEventListener('input', showMinutes);
       showMinutes();
+    }
+    const ioInput = document.getElementById('io_updateHours');
+    const ioLabel = document.getElementById('io_updateMinutes');
+    if (ioInput && ioLabel) {
+      function showMinutesIo() {
+        const val = parseFloat(ioInput.value);
+        ioLabel.textContent = isNaN(val) ? '' : `(${Math.round(val * 60)} min)`;
+      }
+      ioInput.addEventListener('input', showMinutesIo);
+      showMinutesIo();
     }
   });
 </script>

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     path('unprofitable_channels/', views.unprofitable_channels, name='unprofitable-channels'),
     path('actions/', views.actions, name='actions'),
     path('fees/', views.fees, name='fees'),
+    path('inbound-offset/', views.inbound_offset, name='inbound-offset'),
     path('keysends/', views.keysends, name='keysends'),
     path('channels/', views.channels, name='channels'),
     path('autopilot/', views.autopilot, name='autopilot'),

--- a/gui/views.py
+++ b/gui/views.py
@@ -2052,6 +2052,57 @@ def inbound_fee_log(request):
         return redirect('home')
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
+def inbound_offset(request):
+    if request.method == 'GET':
+        channels = Channels.objects.filter(is_open=True)
+        context = {
+            'channels': channels.order_by('alias'),
+            'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
+            'graph_links': graph_links(),
+            'network_links': network_links(),
+            'local_settings': get_local_settings('IO-')
+        }
+        return render(request, 'inbound_offset.html', context)
+    elif request.method == 'POST':
+        form = InboundOffsetForm(request.POST)
+        if form.is_valid() and Channels.objects.filter(chan_id=form.cleaned_data['chan_id']).exists():
+            chan_id = form.cleaned_data['chan_id']
+            offset = form.cleaned_data['offset']
+            db_channel = Channels.objects.get(chan_id=chan_id)
+            db_channel.inbound_offset = offset
+            balance = db_channel.local_fee_rate + offset
+            target = -balance if balance > 0 else 0
+            try:
+                stub = lnrpc.LightningStub(lnd_connect())
+                version = stub.GetInfo(ln.GetInfoRequest()).version
+                if float(version[:4]) >= 0.18:
+                    channel_point = point(db_channel)
+                    inbound_base_fee = db_channel.local_inbound_base_fee if db_channel.local_inbound_base_fee else 0
+                    stub.UpdateChannelPolicy(ln.PolicyUpdateRequest(
+                        chan_point=channel_point,
+                        base_fee_msat=db_channel.local_base_fee,
+                        fee_rate=(db_channel.local_fee_rate/1000000),
+                        time_lock_delta=db_channel.local_cltv,
+                        inbound_fee=ln.InboundFee(base_fee_msat=inbound_base_fee, fee_rate_ppm=target)
+                    ))
+                    old_rate = db_channel.local_inbound_fee_rate if db_channel.local_inbound_fee_rate else 0
+                    db_channel.local_inbound_fee_rate = target
+                    db_channel.offset_updated = datetime.now()
+                    db_channel.save()
+                    InboundFeeLog(chan_id=db_channel.chan_id, peer_alias=db_channel.alias,
+                                  setting='Manual Offset', old_value=old_rate, new_value=target).save()
+                    messages.success(request, f'Inbound fee rate for channel {db_channel.alias} ({db_channel.chan_id}) updated to a value of: {target}')
+                else:
+                    messages.error(request, 'LND version too low to set inbound fees, update to v0.18+')
+            except Exception as e:
+                messages.error(request, f'Error updating channel: {e}')
+        else:
+            messages.error(request, 'Invalid Request. Please try again.')
+        return redirect(request.META.get('HTTP_REFERER', '/'))
+    else:
+        return redirect('home')
+
+@is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def peerevents(request):
     if request.method == 'GET':
         try:
@@ -2255,6 +2306,9 @@ def get_local_settings(*prefixes):
         form.append({'unit': 'x', 'form_id': 'af_lowliqboost', 'value': 1, 'label': 'AF LowLiq Boost', 'id': 'AF-LowLiqBoost', 'title': 'Multiplier for extra fee bump when liquidity is below AF-LowLiqLimit. Default 1', 'min':0, 'max':10})
         form.append({'unit': '', 'form_id': 'af_lowliqboostar', 'value': 0, 'label': 'AF Boost AR Only', 'id': 'AF-LowLiqBoostAR', 'title': 'Apply boost only to channels with Auto-Rebalance enabled; Off disables the boost', 'min':0, 'max':1})
         form.append({'unit': '%', 'form_id': 'af_excess', 'value': 95, 'label': 'AF Excess', 'id': 'AF-ExcessLimit', 'title': 'Limit for running excess liq AF rules (decrease for stagnant channels and those with assisting revenues). Default 95', 'min':0, 'max':100})
+    if 'IO-' in prefixes:
+        form.append({'unit': '', 'form_id': 'io_enabled', 'value': 0, 'label': 'Offset Updates', 'id': 'IO-Enabled', 'title': 'Enable/Disable automatic inbound offset updates', 'min':0, 'max':1})
+        form.append({'unit': 'hours', 'form_id': 'io_updateHours', 'value': 24, 'label': 'IO Update', 'id': 'IO-UpdateHours', 'title': 'Hours between applying inbound offsets. Fractions allowed. Default 24', 'min':0.01, 'max':100})
     if 'GUI-' in prefixes:
         form.append({'unit': '', 'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'label': 'Graph URL', 'id': 'GUI-GraphLinks', 'title': 'Preferred Graph URL. Default https://mempool.space/lightning'})
         form.append({'unit': '', 'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'label': 'NET URL', 'id': 'GUI-NetLinks', 'title': 'Preferred NET URL. Default https://mempool.space'})
@@ -2299,6 +2353,9 @@ def update_settings(request):
                     {'form_id': 'af_lowliqboost', 'value': 1, 'parse': lambda x: float(x),'id': 'AF-LowLiqBoost'},
                     {'form_id': 'af_lowliqboostar', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-LowLiqBoostAR'},
                     {'form_id': 'af_excess', 'value': 95, 'parse': lambda x: int(x),'id': 'AF-ExcessLimit'},
+                    #IO
+                    {'form_id': 'io_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'IO-Enabled'},
+                    {'form_id': 'io_updateHours', 'value': 24, 'parse': lambda x: float(x),'id': 'IO-UpdateHours'},
                     #GUI
                     {'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'parse': lambda x: str(x),'id': 'GUI-GraphLinks'},
                     {'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'parse': lambda x: str(x),'id': 'GUI-NetLinks'},

--- a/jobs.py
+++ b/jobs.py
@@ -660,6 +660,51 @@ def auto_fees(stub):
     except Exception as e:
         print(f"{datetime.now().strftime('%c')} : [Data] : Error processing auto_fees: {str(e)}")
 
+def inbound_offsets(stub):
+    if LocalSettings.objects.filter(key='IO-Enabled').exists():
+        if int(LocalSettings.objects.filter(key='IO-Enabled')[0].value) == 0:
+            return
+    else:
+        LocalSettings(key='IO-Enabled', value='0').save()
+        return
+    if LocalSettings.objects.filter(key='IO-UpdateHours').exists():
+        update_hours = float(LocalSettings.objects.filter(key='IO-UpdateHours')[0].value)
+    else:
+        LocalSettings(key='IO-UpdateHours', value='24').save()
+        update_hours = 24.0
+    threshold = datetime.now() - timedelta(hours=update_hours)
+    version = stub.GetInfo(ln.GetInfoRequest()).version
+    if float(version[:4]) < 0.18:
+        return
+    channels = Channels.objects.filter(is_open=True).exclude(inbound_offset=0)
+    for ch in channels:
+        if not ch.offset_updated or ch.offset_updated < threshold:
+            balance = ch.local_fee_rate + ch.inbound_offset
+            target = -balance if balance > 0 else 0
+            channel_point = ln.ChannelPoint()
+            channel_point.funding_txid_bytes = bytes.fromhex(ch.funding_txid)
+            channel_point.funding_txid_str = ch.funding_txid
+            channel_point.output_index = ch.output_index
+            inbound_base_fee = ch.local_inbound_base_fee if ch.local_inbound_base_fee else 0
+            try:
+                stub.UpdateChannelPolicy(
+                    ln.PolicyUpdateRequest(
+                        chan_point=channel_point,
+                        base_fee_msat=ch.local_base_fee,
+                        fee_rate=(ch.local_fee_rate/1000000),
+                        time_lock_delta=ch.local_cltv,
+                        inbound_fee=ln.InboundFee(base_fee_msat=inbound_base_fee, fee_rate_ppm=target)
+                    )
+                )
+            except Exception as e:
+                print(f"{datetime.now().strftime('%c')} : [Data] : Error updating inbound offset for {ch.chan_id}: {str(e)}")
+                continue
+            if ch.local_inbound_fee_rate != target:
+                InboundFeeLog(chan_id=ch.chan_id, peer_alias=ch.alias, setting='Offset Job', old_value=ch.local_inbound_fee_rate, new_value=target).save()
+            ch.local_inbound_fee_rate = target
+            ch.offset_updated = datetime.now()
+            ch.save()
+
 
 def agg_htlcs(target_htlcs, category):
     try:
@@ -714,6 +759,7 @@ def main():
             reconnect_peers(stub)
             clean_payments(stub)
             auto_fees(stub)
+            inbound_offsets(stub)
             agg_failed_htlcs()
         except Exception as e:
             print(f"{datetime.now().strftime('%c')} : [Data] : Error processing background data: {str(e)}")


### PR DESCRIPTION
## Summary
- store per-channel inbound offset and last run time
- add Inbound Offset settings (enable & update interval)
- auto-apply offsets in new background job
- display offset controls with settings on Inbound Offset page
- show update interval in minutes in settings form
- handle failures when applying inbound offsets

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68565a8e3254832eadc6007b157ab0cb