### PR TITLE
Improve node info caching

### DIFF
--- a/gui/forms.py
+++ b/gui/forms.py
@@ -78,6 +78,8 @@ class LocalSettingsForm(GUIForm):
     mx_enabled = forms.IntegerField(label='mx_enabled', required=False)
     mx_updateHours = forms.FloatField(label='mx_updateHours', required=False)
     mx_percent = forms.IntegerField(label='mx_percent', required=False)
+    node_cache_expiry_minutes = forms.IntegerField(label='node_cache_expiry_minutes', required=False)
+    node_cache_max_entries = forms.IntegerField(label='node_cache_max_entries', required=False)
 
 updates_channel_codes = [
     (0, 'base_fee'),

--- a/gui/node_cache.py
+++ b/gui/node_cache.py
@@ -1,33 +1,60 @@
 from datetime import timedelta
+from collections import OrderedDict
+
 from django.utils import timezone
 from google.protobuf.json_format import MessageToDict, ParseDict
 
 from .models import NodeCache, LocalSettings
 from gui.lnd_deps import lightning_pb2 as ln
 
+_memory_cache = OrderedDict()
 
-def get_node_info_cached(pubkey, stub, expiry_minutes=60):
-    """Return node info using a simple database cache."""
-    setting = LocalSettings.objects.filter(key='NODE_CACHE_EXPIRY_MINUTES').first()
-    if setting:
+
+def get_node_info_cached(pubkey, stub, expiry_minutes=60, max_entries=500):
+    """Return node info using a combined in-memory and database cache."""
+    expiry_setting = LocalSettings.objects.filter(key='NODE_CACHE_EXPIRY_MINUTES').first()
+    if expiry_setting:
         try:
-            expiry_minutes = int(setting.value)
+            expiry_minutes = int(expiry_setting.value)
         except ValueError:
             pass
+
+    max_setting = LocalSettings.objects.filter(key='NODE_CACHE_MAX_ENTRIES').first()
+    if max_setting:
+        try:
+            max_entries = int(max_setting.value)
+        except ValueError:
+            pass
+
     cutoff = timezone.now() - timedelta(minutes=expiry_minutes)
+
+    mem_entry = _memory_cache.get(pubkey)
+    if mem_entry:
+        info, updated_at = mem_entry
+        if updated_at >= cutoff:
+            _memory_cache.move_to_end(pubkey)
+            return info
+        else:
+            _memory_cache.pop(pubkey, None)
+
     cache = NodeCache.objects.filter(pubkey=pubkey).first()
-    if not cache or cache.updated_at < cutoff:
+    if cache and cache.updated_at >= cutoff:
+        info = ParseDict(cache.data, ln.NodeInfo())
+    else:
         try:
             info = stub.GetNodeInfo(ln.NodeInfoRequest(pub_key=pubkey, include_channels=False))
             NodeCache.objects.update_or_create(
                 pubkey=pubkey,
                 defaults={'data': MessageToDict(info), 'updated_at': timezone.now()},
             )
-            return info
         except Exception:
             if cache:
-                return ParseDict(cache.data, ln.NodeInfo())
-            raise
-    else:
-        return ParseDict(cache.data, ln.NodeInfo())
+                info = ParseDict(cache.data, ln.NodeInfo())
+            else:
+                raise
+
+    if len(_memory_cache) >= max_entries:
+        _memory_cache.popitem(last=False)
+    _memory_cache[pubkey] = (info, timezone.now())
+    return info
 

--- a/gui/node_cache.py
+++ b/gui/node_cache.py
@@ -58,3 +58,15 @@ def get_node_info_cached(pubkey, stub, expiry_minutes=60, max_entries=500):
     _memory_cache[pubkey] = (info, timezone.now())
     return info
 
+
+def cache_stats():
+    """Return current size and memory usage of the in-memory node cache."""
+    total_bytes = 0
+    for info, _ in _memory_cache.values():
+        try:
+            total_bytes += info.ByteSize()
+        except Exception:
+            # Fallback for unexpected objects
+            total_bytes += 0
+    return len(_memory_cache), total_bytes
+

--- a/gui/templates/advanced.html
+++ b/gui/templates/advanced.html
@@ -254,6 +254,11 @@
 {% if local_settings %}
 {% include 'local_settings.html' with settings=local_settings title='Update Local' %}
 {% endif %}
+{% if node_cache_entries is not None %}
+<div class="w3-container w3-padding-small">
+  <small>Node cache: {{ node_cache_entries }} entries (~{{ node_cache_mb }} MB RAM)</small>
+</div>
+{% endif %}
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
     const node_info = await GET('node_info', {data: {limit:1}})

--- a/gui/views.py
+++ b/gui/views.py
@@ -13,7 +13,7 @@ from rest_framework.permissions import IsAuthenticated
 from .forms import *
 from .serializers import *
 from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, InboundFeeLog, PendingChannels, AvoidNodes, PeerEvents, HistFailedHTLC, TradeSales, RebalanceRoute, AllowedTarget, calc_success_ratio
-from gui.node_cache import get_node_info_cached
+from gui.node_cache import get_node_info_cached, cache_stats
 from gui.lnd_deps import lightning_pb2 as ln
 from gui.lnd_deps import lightning_pb2_grpc as lnrpc
 from gui.lnd_deps import router_pb2 as lnr
@@ -230,11 +230,14 @@ def advanced(request):
             channels_df['local_max_htlc'] = channels_df['local_max_htlc_msat']/1000
         context = {
             'channels': channels_df.to_dict(orient='records'),
-            'local_settings': get_local_settings('AF-', 'AR-', 'GUI-', 'LND-'),
+            'local_settings': get_local_settings('AF-', 'AR-', 'GUI-', 'LND-', 'NODE_CACHE'),
             'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
             'graph_links': graph_links(),
             'network_links': network_links()
         }
+        entries, bytes_used = cache_stats()
+        context['node_cache_entries'] = entries
+        context['node_cache_mb'] = round(bytes_used / 1024 / 1024, 2)
         return render(request, 'advanced.html', context)
     else:
         return redirect('home')
@@ -2369,6 +2372,9 @@ def get_local_settings(*prefixes):
         form.append({'unit': '', 'form_id': 'mx_enabled', 'value': 0, 'label': 'MaxHTLC Updates', 'id': 'MX-Enabled', 'title': 'Enable/Disable automatic max HTLC updates', 'min':0, 'max':1})
         form.append({'unit': 'hours', 'form_id': 'mx_updateHours', 'value': 24, 'label': 'MX Update', 'id': 'MX-UpdateHours', 'title': 'Hours between applying max HTLC settings. Fractions allowed. Default 24', 'min':0.01, 'max':100})
         form.append({'unit': '%', 'form_id': 'mx_percent', 'value': 0, 'label': 'Offset %', 'id': 'MX-Percent', 'title': 'Default percent below outbound liquidity when no per-channel value is set', 'min':0, 'max':100})
+    if 'NODE_CACHE' in prefixes:
+        form.append({'unit': 'min', 'form_id': 'node_cache_expiry_minutes', 'value': 60, 'label': 'Node Cache Expiry', 'id': 'NODE_CACHE_EXPIRY_MINUTES', 'title': 'Minutes node info is cached in memory and DB before refresh', 'min':1, 'max':10080})
+        form.append({'unit': '', 'form_id': 'node_cache_max_entries', 'value': 500, 'label': 'Node Cache Size', 'id': 'NODE_CACHE_MAX_ENTRIES', 'title': 'Maximum number of node info objects kept in RAM', 'min':1, 'max':5000})
     if 'GUI-' in prefixes:
         form.append({'unit': '', 'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'label': 'Graph URL', 'id': 'GUI-GraphLinks', 'title': 'Preferred Graph URL. Default https://mempool.space/lightning'})
         form.append({'unit': '', 'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'label': 'NET URL', 'id': 'GUI-NetLinks', 'title': 'Preferred NET URL. Default https://mempool.space'})
@@ -2426,6 +2432,9 @@ def update_settings(request):
                     #LND
                     {'form_id': 'lnd_cleanPayments', 'value': 0, 'parse': lambda x: int(x), 'id': 'LND-CleanPayments'},
                     {'form_id': 'lnd_retentionDays', 'value': 30, 'parse': lambda x: int(x), 'id': 'LND-RetentionDays'},
+                    # Node Cache
+                    {'form_id': 'node_cache_expiry_minutes', 'value': 60, 'parse': lambda x: int(x), 'id': 'NODE_CACHE_EXPIRY_MINUTES'},
+                    {'form_id': 'node_cache_max_entries', 'value': 500, 'parse': lambda x: int(x), 'id': 'NODE_CACHE_MAX_ENTRIES'},
                     ]
 
         form = LocalSettingsForm(request.POST)

--- a/jobs.py
+++ b/jobs.py
@@ -214,10 +214,18 @@ def update_forwards(stub):
     forwards = response.forwarding_events
     if not forwards:
         return
+
+    chan_ids = set()
+    for f in forwards:
+        chan_ids.add(str(f.chan_id_in))
+        chan_ids.add(str(f.chan_id_out))
+
+    chan_map = {c.chan_id: c for c in Channels.objects.filter(chan_id__in=chan_ids)}
+
     new_forwards = []
     for forward in forwards:
-        inbound_channel = Channels.objects.get(chan_id=forward.chan_id_in) if Channels.objects.filter(chan_id=forward.chan_id_in).exists() else None
-        outbound_channel = Channels.objects.get(chan_id=forward.chan_id_out) if Channels.objects.filter(chan_id=forward.chan_id_out).exists() else None
+        inbound_channel = chan_map.get(str(forward.chan_id_in))
+        outbound_channel = chan_map.get(str(forward.chan_id_out))
         forward_datetime = datetime.fromtimestamp(forward.timestamp)
         amt_in_msat = forward.amt_in_msat
         amt_out_msat = forward.amt_out_msat


### PR DESCRIPTION
## Summary
- add an in-memory LRU cache to `get_node_info_cached`
- make cache size configurable via `NODE_CACHE_MAX_ENTRIES`
- reduce database queries in `update_forwards` by preloading channel objects
