### PR TITLE
Add remote oRate limit for Auto-Fee LowLiq increases

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24).
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.
 - `AF-ExcessLimit`: Outbound liquidity (%) threshold above which the "Excess Liquidity" fee algorithm applies.
-- `AF-RemoteFeeLimit`: Maximum peer oRate for LowLiq fee increases.
+- `AF-RemoteFeeLimit`: Maximum peer oRate for LowLiq fee increases (default: 1000).
 
 ### Auto-Fees Notes
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24).
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.
 - `AF-ExcessLimit`: Outbound liquidity (%) threshold above which the "Excess Liquidity" fee algorithm applies.
+- `AF-RemoteFeeLimit`: Maximum peer oRate for LowLiq fee increases.
 
 ### Auto-Fees Notes
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-MinRate`: Minimum fee rate (ppm) AF can set.
 - `AF-Multiplier`: Multiplies the `AF-Increment` for larger fee adjustments.
 - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24).
-- `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.
+- `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies (default: 15).
 - `AF-ExcessLimit`: Outbound liquidity (%) threshold above which the "Excess Liquidity" fee algorithm applies.
 - `AF-RemoteFeeLimit`: Maximum peer oRate for LowLiq fee increases (default: 1000).
 

--- a/af.py
+++ b/af.py
@@ -47,7 +47,7 @@ def main(channels):
         lowliq_limit = int(LocalSettings.objects.filter(key='AF-LowLiqLimit').get().value)
     else:
         LocalSettings(key='AF-LowLiqLimit', value='15').save()
-        lowliq_limit = 5
+        lowliq_limit = 15
     if LocalSettings.objects.filter(key='AF-ExcessLimit').exists():
         excess_limit = int(LocalSettings.objects.filter(key='AF-ExcessLimit').get().value)
     else:

--- a/af.py
+++ b/af.py
@@ -54,7 +54,11 @@ def main(channels):
         LocalSettings(key='AF-ExcessLimit', value='95').save()
         excess_limit = 95
     if LocalSettings.objects.filter(key='AF-RemoteFeeLimit').exists():
-        remote_limit = int(LocalSettings.objects.filter(key='AF-RemoteFeeLimit').get().value)
+        try:
+            remote_limit = int(float(LocalSettings.objects.filter(key='AF-RemoteFeeLimit').get().value))
+        except (ValueError, TypeError):
+            remote_limit = 1000
+            LocalSettings.objects.filter(key='AF-RemoteFeeLimit').update(value='1000')
     else:
         LocalSettings(key='AF-RemoteFeeLimit', value='1000').save()
         remote_limit = 1000

--- a/af.py
+++ b/af.py
@@ -53,6 +53,11 @@ def main(channels):
     else:
         LocalSettings(key='AF-ExcessLimit', value='95').save()
         excess_limit = 95
+    if LocalSettings.objects.filter(key='AF-RemoteFeeLimit').exists():
+        remote_limit = int(LocalSettings.objects.filter(key='AF-RemoteFeeLimit').get().value)
+    else:
+        LocalSettings(key='AF-RemoteFeeLimit', value='1000').save()
+        remote_limit = 1000
     if lowliq_limit >= excess_limit:
         print('Invalid thresholds detected, using defaults...')
         lowliq_limit = 5
@@ -219,6 +224,12 @@ def main(channels):
     channels_df['new_rate'] = channels_df['local_fee_rate'] + channels_df['adjustment']
     channels_df['new_rate'] = (channels_df['new_rate'] / increment).round(0) * increment
     channels_df['new_rate'] = channels_df['new_rate'].clip(min_rate, max_rate)
+    condition = (
+        (channels_df['adjustment'] > 0) &
+        (channels_df['overall_out_percent'] <= lowliq_limit) &
+        (channels_df['remote_fee_rate'] >= remote_limit)
+    )
+    channels_df.loc[condition, 'new_rate'] = channels_df.loc[condition, 'local_fee_rate']
     channels_df['adjustment'] = channels_df['new_rate'] - channels_df['local_fee_rate']
 
     # Compute new inbound rates

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -63,6 +63,7 @@ class AutoFeesForm(AutoRebalanceForm):
     af_updateHours = forms.IntegerField(label='af_updateHours', required=False)
     af_lowliq = forms.IntegerField(label='af_lowliq', required=False)
     af_excess = forms.IntegerField(label='af_excess', required=False)
+    af_remote_fee_limit = forms.IntegerField(label='af_remote_fee_limit', required=False)
 
 class GUIForm(AutoFeesForm):
     gui_graphLinks = forms.CharField(label='gui_graphLinks', required=False)

--- a/gui/views.py
+++ b/gui/views.py
@@ -2069,7 +2069,7 @@ def update_settings(request):
                     {'form_id': 'af_updateHours', 'value': 24, 'parse': lambda x: int(x),'id': 'AF-UpdateHours'},
                     {'form_id': 'af_lowliq', 'value': 15, 'parse': lambda x: int(x),'id': 'AF-LowLiqLimit'},
                     {'form_id': 'af_excess', 'value': 95, 'parse': lambda x: int(x),'id': 'AF-ExcessLimit'},
-                    {'form_id': 'af_remote_fee_limit', 'value': 1000, 'parse': lambda x: int(x),'id': 'AF-RemoteFeeLimit'},
+                    {'form_id': 'af_remote_fee_limit', 'value': 1000, 'parse': lambda x: int(float(x)), 'id': 'AF-RemoteFeeLimit'},
                     #GUI
                     {'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'parse': lambda x: str(x),'id': 'GUI-GraphLinks'},
                     {'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'parse': lambda x: str(x),'id': 'GUI-NetLinks'},

--- a/gui/views.py
+++ b/gui/views.py
@@ -2026,6 +2026,7 @@ def get_local_settings(*prefixes):
         form.append({'unit': 'hours', 'form_id': 'af_updateHours', 'value': 24, 'label': 'AF Update', 'id': 'AF-UpdateHours', 'title': 'Minimum number of hours between fee updates for an individual channel. Default 24', 'min':1, 'max':100})
         form.append({'unit': '%', 'form_id': 'af_lowliq', 'value': 15, 'label': 'AF LowLiq', 'id': 'AF-LowLiqLimit', 'title': 'Limit for running low liq AF rules (increase when failed htlcs + no inbound). Default 15', 'min':0, 'max':100})
         form.append({'unit': '%', 'form_id': 'af_excess', 'value': 95, 'label': 'AF Excess', 'id': 'AF-ExcessLimit', 'title': 'Limit for running excess liq AF rules (decrease for stagnant channels and those with assisting revenues). Default 95', 'min':0, 'max':100})
+        form.append({'unit': 'ppm', 'form_id': 'af_remote_fee_limit', 'value': 1000, 'label': 'AF Remote Limit', 'id': 'AF-RemoteFeeLimit', 'title': 'Only raise fees under AF-LowLiq if peer oRate is below this value. Default 1000', 'min':0, 'max':5000})
     if 'GUI-' in prefixes:
         form.append({'unit': '', 'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'label': 'Graph URL', 'id': 'GUI-GraphLinks', 'title': 'Preferred Graph URL. Default https://mempool.space/lightning'})
         form.append({'unit': '', 'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'label': 'NET URL', 'id': 'GUI-NetLinks', 'title': 'Preferred NET URL. Default https://mempool.space'})
@@ -2068,6 +2069,7 @@ def update_settings(request):
                     {'form_id': 'af_updateHours', 'value': 24, 'parse': lambda x: int(x),'id': 'AF-UpdateHours'},
                     {'form_id': 'af_lowliq', 'value': 15, 'parse': lambda x: int(x),'id': 'AF-LowLiqLimit'},
                     {'form_id': 'af_excess', 'value': 95, 'parse': lambda x: int(x),'id': 'AF-ExcessLimit'},
+                    {'form_id': 'af_remote_fee_limit', 'value': 1000, 'parse': lambda x: int(x),'id': 'AF-RemoteFeeLimit'},
                     #GUI
                     {'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'parse': lambda x: str(x),'id': 'GUI-GraphLinks'},
                     {'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'parse': lambda x: str(x),'id': 'GUI-NetLinks'},


### PR DESCRIPTION
## Summary
- add new setting `AF-RemoteFeeLimit` to cap fee increases when peer fees are high
- expose the setting in autofee forms and settings page
- apply remote fee limit logic in `af.py`
- document the new setting in README

## Testing
- `python -m py_compile af.py gui/forms.py gui/views.py`

------
https://chatgpt.com/codex/tasks/task_e_6857d6891804832e82fcc09ab7842614