### PR TITLE
Add peer oRate limit check for AF LowLiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,14 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.
 - `AF-LowLiqBoost`: Scaling factor applied when liquidity is below `AF-LowLiqLimit` (default: 1).
 - `AF-LowLiqBoostAR`: When `1`, apply the low-liquidity boost only to channels with Auto-Rebalance enabled; `0` disables the boost entirely.
+- `AF-PeerRateLimit`: Maximum peer oRate (ppm) for applying low-liquidity fee increases. `0` disables this check.
+- `AF-PeerRateCheck`: Enable (`1`) or disable (`0`) the peer oRate limit evaluation.
 - `AF-ExcessLimit`: Outbound liquidity (%) threshold above which the "Excess Liquidity" fee algorithm applies.
 
 ### Auto-Fees Notes
 
 1.  AF adjustments occur only if `AF-UpdateHours` have passed since the last LNDg fee update for that channel (fractions are supported).
-2.  Channels below `AF-LowLiqLimit`% outbound liquidity may see fee increases based on failed HTLCs and incoming flow.
+2.  Channels below `AF-LowLiqLimit`% outbound liquidity may see fee increases based on failed HTLCs and incoming flow. When `AF-PeerRateCheck` is enabled, increases only occur if the peer's oRate is below `AF-PeerRateLimit`.
 3.  Channels above `AF-ExcessLimit`% outbound liquidity may see fee decreases based on lack of flow or assisted revenue.
 4.  Channels between these limits adjust based on overall flow patterns.
 5.  View AF change history in the "Autofees" tab.

--- a/af.py
+++ b/af.py
@@ -64,6 +64,16 @@ def main(channels):
     else:
         LocalSettings(key='AF-LowLiqBoostAR', value='0').save()
         boost_ar_only = False
+    if LocalSettings.objects.filter(key='AF-PeerRateCheck').exists():
+        peer_rate_check = LocalSettings.objects.filter(key='AF-PeerRateCheck').get().value == '1'
+    else:
+        LocalSettings(key='AF-PeerRateCheck', value='0').save()
+        peer_rate_check = False
+    if LocalSettings.objects.filter(key='AF-PeerRateLimit').exists():
+        peer_rate_limit = int(LocalSettings.objects.filter(key='AF-PeerRateLimit').get().value)
+    else:
+        LocalSettings(key='AF-PeerRateLimit', value='0').save()
+        peer_rate_limit = 0
     if lowliq_limit >= excess_limit:
         print('Invalid thresholds detected, using defaults...')
         lowliq_limit = 5
@@ -241,6 +251,8 @@ def main(channels):
     # Define outbound adjustment calculation function (per channel)
     def compute_outbound_adjustment(row):
         if row['out_percent'] <= lowliq_limit:
+            if peer_rate_check and peer_rate_limit > 0 and row['remote_fee_rate'] >= peer_rate_limit:
+                return 0
             boost = 0
             if boost_ar_only and row.get('auto_rebalance'):
                 deficit = max(0, lowliq_limit - row['out_percent'])

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -64,6 +64,8 @@ class AutoFeesForm(AutoRebalanceForm):
     af_lowliq = forms.IntegerField(label='af_lowliq', required=False)
     af_lowliqboost = forms.FloatField(label='af_lowliqboost', required=False)
     af_lowliqboostar = forms.IntegerField(label='af_lowliqboostar', required=False)
+    af_peer_rate_limit = forms.IntegerField(label='af_peer_rate_limit', required=False)
+    af_peer_rate_check = forms.IntegerField(label='af_peer_rate_check', required=False)
     af_excess = forms.IntegerField(label='af_excess', required=False)
 
 class GUIForm(AutoFeesForm):

--- a/gui/views.py
+++ b/gui/views.py
@@ -2364,6 +2364,8 @@ def get_local_settings(*prefixes):
         form.append({'unit': '%', 'form_id': 'af_lowliq', 'value': 15, 'label': 'AF LowLiq', 'id': 'AF-LowLiqLimit', 'title': 'Limit for running low liq AF rules (increase when failed htlcs + no inbound). Default 15', 'min':0, 'max':100})
         form.append({'unit': 'x', 'form_id': 'af_lowliqboost', 'value': 1, 'label': 'AF LowLiq Boost', 'id': 'AF-LowLiqBoost', 'title': 'Multiplier for extra fee bump when liquidity is below AF-LowLiqLimit. Default 1', 'min':0, 'max':10})
         form.append({'unit': '', 'form_id': 'af_lowliqboostar', 'value': 0, 'label': 'AF Boost AR Only', 'id': 'AF-LowLiqBoostAR', 'title': 'Apply boost only to channels with Auto-Rebalance enabled; Off disables the boost', 'min':0, 'max':1})
+        form.append({'unit': 'ppm', 'form_id': 'af_peer_rate_limit', 'value': 0, 'label': 'Peer oRate Limit', 'id': 'AF-PeerRateLimit', 'title': 'Only raise fees if peer oRate below this limit; 0 disables', 'min':0, 'max':5000})
+        form.append({'unit': '', 'form_id': 'af_peer_rate_check', 'value': 0, 'label': 'Peer Rate Check', 'id': 'AF-PeerRateCheck', 'title': 'Enable/Disable peer oRate limit check', 'min':0, 'max':1})
         form.append({'unit': '%', 'form_id': 'af_excess', 'value': 95, 'label': 'AF Excess', 'id': 'AF-ExcessLimit', 'title': 'Limit for running excess liq AF rules (decrease for stagnant channels and those with assisting revenues). Default 95', 'min':0, 'max':100})
     if 'IO-' in prefixes:
         form.append({'unit': '', 'form_id': 'io_enabled', 'value': 0, 'label': 'Offset Updates', 'id': 'IO-Enabled', 'title': 'Enable/Disable automatic inbound offset updates', 'min':0, 'max':1})
@@ -2418,6 +2420,8 @@ def update_settings(request):
                     {'form_id': 'af_lowliq', 'value': 15, 'parse': lambda x: int(x),'id': 'AF-LowLiqLimit'},
                     {'form_id': 'af_lowliqboost', 'value': 1, 'parse': lambda x: float(x),'id': 'AF-LowLiqBoost'},
                     {'form_id': 'af_lowliqboostar', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-LowLiqBoostAR'},
+                    {'form_id': 'af_peer_rate_limit', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-PeerRateLimit'},
+                    {'form_id': 'af_peer_rate_check', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-PeerRateCheck'},
                     {'form_id': 'af_excess', 'value': 95, 'parse': lambda x: int(x),'id': 'AF-ExcessLimit'},
                     #IO
                     {'form_id': 'io_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'IO-Enabled'},


### PR DESCRIPTION
## Summary
- add PeerRateLimit and PeerRateCheck settings
- enforce peer oRate check during AF LowLiq increases
- document the new settings
