### PR TITLE
Add upper threshold option for Auto MaxHTLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Automatically adjust the `max_htlc_msat` for each channel. Define a percent offs
 
 - **mx_liq_threshold:** When outbound liquidity falls below this sat value, the override activates.
 - **mx_liq_value:** Fixed `max_htlc_msat` (in sats) applied while below the threshold.
+- **mx_liq_upper:** Keep the override active until outbound liquidity exceeds this value.
 - **MX-Percent:** Global percent offset when a channel has no specific percent configured.
 
 Once liquidity recovers above the threshold, the percent-based setting is applied again.

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -164,4 +164,5 @@ class MaxHtlcForm(forms.Form):
     percent = forms.IntegerField(label='percent')
     mx_liq_threshold = forms.IntegerField(label='mx_liq_threshold', required=False)
     mx_liq_value = forms.IntegerField(label='mx_liq_value', required=False)
+    mx_liq_upper = forms.IntegerField(label='mx_liq_upper', required=False)
 

--- a/gui/migrations/0048_channels_mx_liq_upper.py
+++ b/gui/migrations/0048_channels_mx_liq_upper.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gui', '0047_channels_mx_liq_override'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channels',
+            name='mx_liq_upper',
+            field=models.BigIntegerField(default=0),
+        ),
+    ]
+

--- a/gui/models.py
+++ b/gui/models.py
@@ -111,6 +111,7 @@ class Channels(models.Model):
     maxhtlc_updated = models.DateTimeField(null=True, default=None)
     mx_liq_threshold = models.BigIntegerField(default=0)
     mx_liq_value = models.BigIntegerField(default=0)
+    mx_liq_upper = models.BigIntegerField(default=0)
     local_disabled = models.BooleanField()
     local_cltv = models.IntegerField()
     local_min_htlc_msat = models.BigIntegerField()

--- a/gui/templates/auto_maxhtlc.html
+++ b/gui/templates/auto_maxhtlc.html
@@ -14,7 +14,8 @@
         <th onclick="sortTable(event.target, 3, 'int')">Outbound Liquidity</th>
         <th>Offset %</th>
         <th>Liq Threshold</th>
-        <th>Override Value</th>
+        <th>Upper Threshold</th>
+        <th>Override MaxHTLC</th>
       </tr>
       {% for channel in channels %}
       <tr>
@@ -28,6 +29,7 @@
             <input style="text-align:center" type="number" min="0" max="100" name="percent" value="{% if channel.maxhtlc_percent %}{{ channel.maxhtlc_percent }}{% else %}{{ mx_percent }}{% endif %}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
             <input type="hidden" name="mx_liq_threshold" value="{{ channel.mx_liq_threshold|default:0 }}">
             <input type="hidden" name="mx_liq_value" value="{{ channel.mx_liq_value|default:0 }}">
+            <input type="hidden" name="mx_liq_upper" value="{{ channel.mx_liq_upper|default:0 }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
           </form>
         </td>
@@ -36,6 +38,17 @@
             {% csrf_token %}
             <input style="text-align:center" type="number" min="0" name="mx_liq_threshold" value="{{ channel.mx_liq_threshold|default:0 }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
             <input type="hidden" name="percent" value="{% if channel.maxhtlc_percent %}{{ channel.maxhtlc_percent }}{% else %}{{ mx_percent }}{% endif %}">
+            <input type="hidden" name="mx_liq_value" value="{{ channel.mx_liq_value|default:0 }}">
+            <input type="hidden" name="mx_liq_upper" value="{{ channel.mx_liq_upper|default:0 }}">
+            <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
+          </form>
+        </td>
+        <td>
+          <form action="/auto-maxhtlc/" method="post">
+            {% csrf_token %}
+            <input style="text-align:center" type="number" min="0" name="mx_liq_upper" value="{{ channel.mx_liq_upper|default:0 }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="percent" value="{% if channel.maxhtlc_percent %}{{ channel.maxhtlc_percent }}{% else %}{{ mx_percent }}{% endif %}">
+            <input type="hidden" name="mx_liq_threshold" value="{{ channel.mx_liq_threshold|default:0 }}">
             <input type="hidden" name="mx_liq_value" value="{{ channel.mx_liq_value|default:0 }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
           </form>
@@ -46,6 +59,7 @@
             <input style="text-align:center" type="number" min="0" name="mx_liq_value" value="{{ channel.mx_liq_value|default:0 }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
             <input type="hidden" name="percent" value="{% if channel.maxhtlc_percent %}{{ channel.maxhtlc_percent }}{% else %}{{ mx_percent }}{% endif %}">
             <input type="hidden" name="mx_liq_threshold" value="{{ channel.mx_liq_threshold|default:0 }}">
+            <input type="hidden" name="mx_liq_upper" value="{{ channel.mx_liq_upper|default:0 }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
           </form>
         </td>

--- a/gui/views.py
+++ b/gui/views.py
@@ -2134,10 +2134,12 @@ def auto_maxhtlc(request):
             percent = int(form.cleaned_data['percent'])
             mx_liq_threshold = int(form.cleaned_data.get('mx_liq_threshold') or 0)
             mx_liq_value = int(form.cleaned_data.get('mx_liq_value') or 0)
+            mx_liq_upper = int(form.cleaned_data.get('mx_liq_upper') or 0)
             db_channel = Channels.objects.get(chan_id=chan_id)
             db_channel.maxhtlc_percent = percent
             db_channel.mx_liq_threshold = mx_liq_threshold
             db_channel.mx_liq_value = mx_liq_value
+            db_channel.mx_liq_upper = mx_liq_upper
             outbound = db_channel.local_balance + db_channel.pending_outbound
             target = int(outbound * (100 - percent) / 100)
             try:

--- a/jobs.py
+++ b/jobs.py
@@ -802,7 +802,9 @@ def auto_maxhtlc_job(stub):
     for ch in channels:
         outbound = ch.local_balance + ch.pending_outbound
         expected_msat = None
-        if ch.mx_liq_threshold and outbound < ch.mx_liq_threshold:
+        if ch.mx_liq_upper and outbound < ch.mx_liq_upper:
+            expected_msat = ch.mx_liq_value * 1000
+        elif ch.mx_liq_threshold and outbound < ch.mx_liq_threshold:
             expected_msat = ch.mx_liq_value * 1000
         else:
             percent = ch.maxhtlc_percent if ch.maxhtlc_percent else global_percent


### PR DESCRIPTION
## Summary
- add `mx_liq_upper` field on `Channels`
- include `mx_liq_upper` in MaxHtlc form and view
- extend Auto MaxHTLC UI with an "Upper Threshold" column
- update job logic to honor the new threshold
- document `mx_liq_upper` in README
