### PR TITLE
Add emergency fee increase system

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,17 @@ Customize Auto-Fees (AF) behavior via the settings page:
 4.  Channels between these limits adjust based on overall flow patterns.
 5.  View AF change history in the "Autofees" tab.
 
+## Emergency Fee Increases
+
+Automatically raise outbound fee rates when channel liquidity drops. Configure defaults in the `Emergency Fees` tab and override them per channel.
+
+- `EP-Enabled`: Default on/off state for each channel.
+- `EP-DefaultTarget`: Outbound liquidity percentage below which fees increase.
+- `EP-IncreasePct`: Percentage increase applied when triggered.
+- `EP-Cooldown`: Minimum minutes between increases for a channel.
+- `EP-LiveThreshold`: Threshold for immediate increases after forwards.
+- `EP-LiveIncreasePct`: Percentage increase for the live trigger.
+
 ## Auto-Rebalancer
 
 Automatically manage channel liquidity to maintain outbound capacity on profitable routes. See the [Quick Start Guide](https://github.com/cryptosharks131/lndg/blob/master/quickstart.md).

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -85,6 +85,13 @@ class LocalSettingsForm(GUIForm):
     amboss_api_key = forms.CharField(label='amboss_api_key', required=False)
     amb_enabled = forms.IntegerField(label='amb_enabled', required=False)
     amb_updateHours = forms.FloatField(label='amb_updateHours', required=False)
+    ep_enabled = forms.IntegerField(label='ep_enabled', required=False)
+    ep_target_default = forms.IntegerField(label='ep_target_default', required=False)
+    ep_inc_pct = forms.FloatField(label='ep_inc_pct', required=False)
+    ep_cooldown = forms.IntegerField(label='ep_cooldown', required=False)
+    ep_live_threshold = forms.IntegerField(label='ep_live_threshold', required=False)
+    ep_live_inc_pct = forms.FloatField(label='ep_live_inc_pct', required=False)
+    ep_live_peers = forms.CharField(label='ep_live_peers', required=False)
 
 updates_channel_codes = [
     (0, 'base_fee'),
@@ -103,12 +110,18 @@ updates_channel_codes = [
     (13, 'inbound_fee_rate'),
     (14, 'ar_source'),
     (15, 'ar_source_ppm_diff'),
+    (16, 'ep_enabled'),
+    (17, 'ep_target'),
+    (18, 'ep_inc_pct'),
+    (19, 'ep_cooldown'),
+    (20, 'ep_live_threshold'),
+    (21, 'ep_live_inc_pct'),
 ]
 
 class UpdateChannel(forms.Form):
     chan_id = forms.IntegerField(label='chan_id')
-    target = forms.IntegerField(label='target')
-    update_target = forms.ChoiceField(label='update_target', choices=updates_channel_codes)
+    target = forms.FloatField(label='target')
+
 
 class UpdateClosing(forms.Form):
     funding_txid = forms.CharField(label='funding_txid', max_length=64)

--- a/gui/migrations/0051_add_emergency_fields.py
+++ b/gui/migrations/0051_add_emergency_fields.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('gui', '0050_ambosspeerfees'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channels',
+            name='ep_target',
+            field=models.IntegerField(default=50),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='ep_updated',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/gui/migrations/0052_ep_channel_settings.py
+++ b/gui/migrations/0052_ep_channel_settings.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('gui', '0051_add_emergency_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channels',
+            name='ep_enabled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='ep_inc_pct',
+            field=models.FloatField(default=10),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='ep_cooldown',
+            field=models.IntegerField(default=10),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='ep_live_threshold',
+            field=models.IntegerField(default=40),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='ep_live_inc_pct',
+            field=models.FloatField(default=5),
+        ),
+    ]

--- a/gui/models.py
+++ b/gui/models.py
@@ -136,6 +136,13 @@ class Channels(models.Model):
     ar_max_cost = models.IntegerField()
     ar_source = models.BooleanField(default=False)
     ar_source_ppm_diff = models.IntegerField(default=0)
+    ep_enabled = models.BooleanField(default=False)
+    ep_target = models.IntegerField(default=50)
+    ep_inc_pct = models.FloatField(default=10)
+    ep_cooldown = models.IntegerField(default=10)
+    ep_live_threshold = models.IntegerField(default=40)
+    ep_live_inc_pct = models.FloatField(default=5)
+    ep_updated = models.DateTimeField(default=timezone.now)
     fees_updated = models.DateTimeField(default=timezone.now)
     auto_fees = models.BooleanField()
     notes = models.TextField(default='', blank=True)
@@ -176,6 +183,48 @@ class Channels(models.Model):
                 LocalSettings(key='AR-MaxCost%', value='65').save()
                 cost_setting = 65
             self.ar_max_cost = cost_setting
+        if not self.ep_target:
+            if LocalSettings.objects.filter(key='EP-DefaultTarget').exists():
+                ep_setting = int(LocalSettings.objects.filter(key='EP-DefaultTarget')[0].value)
+            else:
+                LocalSettings(key='EP-DefaultTarget', value='50').save()
+                ep_setting = 50
+            self.ep_target = ep_setting
+        if self.ep_enabled is None:
+            if LocalSettings.objects.filter(key='EP-Enabled').exists():
+                enabled = int(LocalSettings.objects.filter(key='EP-Enabled')[0].value)
+            else:
+                LocalSettings(key='EP-Enabled', value='0').save()
+                enabled = 0
+            self.ep_enabled = False if enabled == 0 else True
+        if not self.ep_inc_pct:
+            if LocalSettings.objects.filter(key='EP-IncreasePct').exists():
+                inc_pct = float(LocalSettings.objects.filter(key='EP-IncreasePct')[0].value)
+            else:
+                LocalSettings(key='EP-IncreasePct', value='10').save()
+                inc_pct = 10
+            self.ep_inc_pct = inc_pct
+        if not self.ep_cooldown:
+            if LocalSettings.objects.filter(key='EP-Cooldown').exists():
+                cooldown = int(LocalSettings.objects.filter(key='EP-Cooldown')[0].value)
+            else:
+                LocalSettings(key='EP-Cooldown', value='10').save()
+                cooldown = 10
+            self.ep_cooldown = cooldown
+        if not self.ep_live_threshold:
+            if LocalSettings.objects.filter(key='EP-LiveThreshold').exists():
+                threshold = int(LocalSettings.objects.filter(key='EP-LiveThreshold')[0].value)
+            else:
+                LocalSettings(key='EP-LiveThreshold', value='40').save()
+                threshold = 40
+            self.ep_live_threshold = threshold
+        if not self.ep_live_inc_pct:
+            if LocalSettings.objects.filter(key='EP-LiveIncreasePct').exists():
+                live_inc = float(LocalSettings.objects.filter(key='EP-LiveIncreasePct')[0].value)
+            else:
+                LocalSettings(key='EP-LiveIncreasePct', value='5').save()
+                live_inc = 5
+            self.ep_live_inc_pct = live_inc
         super(Channels, self).save(*args, **kwargs)
 
     class Meta:

--- a/gui/templates/emergency_fees.html
+++ b/gui/templates/emergency_fees.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% block title %} {{ block.super }} - Emergency Fees{% endblock %}
+{% block content %}
+{% load humanize %}
+<div class="w3-container w3-padding-small">
+  <h2>Emergency Fee Settings</h2>
+  <div class="w3-container w3-padding-small" style="overflow:auto;max-height:800px">
+    <table class="w3-table-all w3-centered w3-hoverable">
+      <tr>
+        <th>Peer</th>
+        <th>Chan ID</th>
+        <th>Outbound %</th>
+        <th>Enabled</th>
+        <th>Target %</th>
+        <th>Increase %</th>
+        <th>Cooldown</th>
+        <th>Live Threshold</th>
+        <th>Live Increase %</th>
+      </tr>
+      {% for ch in channels %}
+      <tr>
+        <td>{{ ch.alias }}</td>
+        <td><a href="/channel?={{ ch.chan_id }}" target="_blank">{{ ch.chan_id }}</a></td>
+        <td>{{ ch.outbound_percent|floatformat:1 }}</td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="submit" value="{% if ch.ep_enabled %}Disable{% else %}Enable{% endif %}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="16">
+            <input type="hidden" name="target" value="0">
+          </form>
+        </td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="number" style="width:60px;text-align:center" min="0" max="100" name="target" value="{{ ch.ep_target }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="17">
+          </form>
+        </td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="number" style="width:60px;text-align:center" step="0.1" name="target" value="{{ ch.ep_inc_pct }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="18">
+          </form>
+        </td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="number" style="width:60px;text-align:center" min="1" name="target" value="{{ ch.ep_cooldown }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="19">
+          </form>
+        </td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="number" style="width:60px;text-align:center" min="0" max="100" name="target" value="{{ ch.ep_live_threshold }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="20">
+          </form>
+        </td>
+        <td>
+          <form action="/update_channel/" method="post">
+            {% csrf_token %}
+            <input type="number" style="width:60px;text-align:center" step="0.1" name="target" value="{{ ch.ep_live_inc_pct }}" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+            <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+            <input type="hidden" name="update_target" value="21">
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>
+{% if local_settings %}
+{% include 'local_settings.html' with settings=local_settings title='Emergency Fees' %}
+{% endif %}
+{% endblock %}

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -147,6 +147,7 @@
   <a class="w3-bar-item w3-hover-blue" href="/amboss-fees" target="_blank">Amboss Fees</a>
   <a class="w3-bar-item w3-hover-blue" href="/inbound-offset" target="_blank">Inbound Offset</a>
   <a class="w3-bar-item w3-hover-blue" href="/auto-maxhtlc" target="_blank">Auto MaxHTLC</a>
+  <a class="w3-bar-item w3-hover-blue" href="/emergency-fees" target="_blank">Emergency Fees</a>
   <a class="w3-bar-item w3-hover-blue" href="/autopilot" target="_blank">Autopilot</a>
   <a class="w3-bar-item w3-hover-blue" href="/autofees" target="_blank">Outbound Fee Log</a>
   <a class="w3-bar-item w3-hover-blue" href="/inbound-fee-log" target="_blank">Inbound Fee Log</a>

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     path('amboss-fees/', views.amboss_fees, name='amboss-fees'),
     path('inbound-offset/', views.inbound_offset, name='inbound-offset'),
     path('auto-maxhtlc/', views.auto_maxhtlc, name='auto-maxhtlc'),
+    path('emergency-fees/', views.emergency_fees, name='emergency-fees'),
     path('keysends/', views.keysends, name='keysends'),
     path('channels/', views.channels, name='channels'),
     path('autopilot/', views.autopilot, name='autopilot'),

--- a/gui/views.py
+++ b/gui/views.py
@@ -2273,6 +2273,21 @@ def auto_maxhtlc(request):
         return redirect('home')
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
+def emergency_fees(request):
+    if request.method == 'GET':
+        channels = Channels.objects.filter(is_open=True).annotate(outbound_percent=((F('local_balance')+F('pending_outbound'))*100)/F('capacity'))
+        context = {
+            'channels': channels.order_by('alias'),
+            'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
+            'graph_links': graph_links(),
+            'network_links': network_links(),
+            'local_settings': get_local_settings('EP-')
+        }
+        return render(request, 'emergency_fees.html', context)
+    else:
+        return redirect('home')
+
+@is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def peerevents(request):
     if request.method == 'GET':
         try:
@@ -2485,6 +2500,14 @@ def get_local_settings(*prefixes):
         form.append({'unit': '', 'form_id': 'mx_enabled', 'value': 0, 'label': 'MaxHTLC Updates', 'id': 'MX-Enabled', 'title': 'Enable/Disable automatic max HTLC updates', 'min':0, 'max':1})
         form.append({'unit': 'hours', 'form_id': 'mx_updateHours', 'value': 24, 'label': 'MX Update', 'id': 'MX-UpdateHours', 'title': 'Hours between applying max HTLC settings. Fractions allowed. Default 24', 'min':0.01, 'max':100})
         form.append({'unit': '%', 'form_id': 'mx_percent', 'value': 0, 'label': 'Offset %', 'id': 'MX-Percent', 'title': 'Default percent below outbound liquidity when no per-channel value is set', 'min':0, 'max':100})
+    if 'EP-' in prefixes:
+        form.append({'unit': '', 'form_id': 'update_channels', 'id': 'update_channels'})
+        form.append({'unit': '', 'form_id': 'ep_enabled', 'value': 0, 'label': 'Enable', 'id': 'EP-Enabled', 'title': 'Enable/Disable emergency fee increases', 'min':0, 'max':1})
+        form.append({'unit': '%', 'form_id': 'ep_target_default', 'value': 50, 'label': 'Default Target', 'id': 'EP-DefaultTarget', 'title': 'Default outbound liquidity target percent', 'min':0, 'max':100})
+        form.append({'unit': '%', 'form_id': 'ep_inc_pct', 'value': 10, 'label': 'Increase %', 'id': 'EP-IncreasePct', 'title': 'Percent increase when triggered', 'min':0})
+        form.append({'unit': 'min', 'form_id': 'ep_cooldown', 'value': 10, 'label': 'Cooldown', 'id': 'EP-Cooldown', 'title': 'Minutes between increases', 'min':1})
+        form.append({'unit': '%', 'form_id': 'ep_live_threshold', 'value': 40, 'label': 'Live Threshold', 'id': 'EP-LiveThreshold', 'title': 'Instant check threshold percent', 'min':0, 'max':100})
+        form.append({'unit': '%', 'form_id': 'ep_live_inc_pct', 'value': 5, 'label': 'Live Increase %', 'id': 'EP-LiveIncreasePct', 'title': 'Instant increase percent', 'min':0})
     if 'NODE_CACHE' in prefixes:
         form.append({'unit': 'min', 'form_id': 'node_cache_expiry_minutes', 'value': 60, 'label': 'Node Cache Expiry', 'id': 'NODE_CACHE_EXPIRY_MINUTES', 'title': 'Minutes node info is cached in memory and DB before refresh', 'min':1, 'max':10080})
         form.append({'unit': '', 'form_id': 'node_cache_max_entries', 'value': 500, 'label': 'Node Cache Size', 'id': 'NODE_CACHE_MAX_ENTRIES', 'title': 'Maximum number of node info objects kept in RAM', 'min':1, 'max':5000})
@@ -2548,6 +2571,13 @@ def update_settings(request):
                     {'form_id': 'mx_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'MX-Enabled'},
                     {'form_id': 'mx_updateHours', 'value': 24, 'parse': lambda x: float(x),'id': 'MX-UpdateHours'},
                     {'form_id': 'mx_percent', 'value': 0, 'parse': lambda x: int(x),'id': 'MX-Percent'},
+                    #EP
+                    {'form_id': 'ep_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'EP-Enabled'},
+                    {'form_id': 'ep_target_default', 'value': 50, 'parse': lambda x: int(x),'id': 'EP-DefaultTarget'},
+                    {'form_id': 'ep_inc_pct', 'value': 10, 'parse': lambda x: float(x),'id': 'EP-IncreasePct'},
+                    {'form_id': 'ep_cooldown', 'value': 10, 'parse': lambda x: int(x),'id': 'EP-Cooldown'},
+                    {'form_id': 'ep_live_threshold', 'value': 40, 'parse': lambda x: int(x),'id': 'EP-LiveThreshold'},
+                    {'form_id': 'ep_live_inc_pct', 'value': 5, 'parse': lambda x: float(x),'id': 'EP-LiveIncreasePct'},
                     #GUI
                     {'form_id': 'gui_graphLinks', 'value': 'https://mempool.space/lightning', 'parse': lambda x: str(x),'id': 'GUI-GraphLinks'},
                     {'form_id': 'gui_netLinks', 'value': 'https://mempool.space', 'parse': lambda x: str(x),'id': 'GUI-NetLinks'},
@@ -2586,7 +2616,7 @@ def update_settings(request):
                     db_value.value = value
                     db_value.save()
 
-                    if update_channels and field['id'] in ['AR-Target%', 'AR-Outbound%','AR-Inbound%','AR-MaxCost%','MX-Percent']:
+                    if update_channels and field['id'] in ['AR-Target%', 'AR-Outbound%','AR-Inbound%','AR-MaxCost%','MX-Percent','EP-DefaultTarget','EP-IncreasePct','EP-Cooldown','EP-LiveThreshold','EP-LiveIncreasePct','EP-Enabled']:
                         if field['id'] == 'AR-Target%':
                             Channels.objects.all().update(ar_amt_target=Round(F('capacity')*(value/100), output_field=IntegerField()))
                         elif field['id'] == 'AR-Outbound%':
@@ -2597,6 +2627,18 @@ def update_settings(request):
                             Channels.objects.all().update(ar_max_cost=value)
                         elif field['id'] == 'MX-Percent':
                             Channels.objects.all().update(maxhtlc_percent=value)
+                        elif field['id'] == 'EP-DefaultTarget':
+                            Channels.objects.all().update(ep_target=value)
+                        elif field['id'] == 'EP-IncreasePct':
+                            Channels.objects.all().update(ep_inc_pct=value)
+                        elif field['id'] == 'EP-Cooldown':
+                            Channels.objects.all().update(ep_cooldown=value)
+                        elif field['id'] == 'EP-LiveThreshold':
+                            Channels.objects.all().update(ep_live_threshold=value)
+                        elif field['id'] == 'EP-LiveIncreasePct':
+                            Channels.objects.all().update(ep_live_inc_pct=value)
+                        elif field['id'] == 'EP-Enabled':
+                            Channels.objects.all().update(ep_enabled=bool(value))
                         messages.success(request, 'All channels ' + field['id'] + ' updated to: ' + str(value))
                     else:
                         messages.success(request, field['id'] + ' updated to: ' + str(value))
@@ -2715,6 +2757,30 @@ def update_channel(request):
                 db_channel.ar_source_ppm_diff = target
                 db_channel.save()
                 messages.success(request, 'Source ppm diff for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target))
+            elif update_target == 16:
+                db_channel.ep_enabled = not db_channel.ep_enabled
+                db_channel.save()
+                messages.success(request, 'Emergency fees status for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') set to: ' + str(db_channel.ep_enabled))
+            elif update_target == 17:
+                db_channel.ep_target = int(target)
+                db_channel.save()
+                messages.success(request, 'Emergency target for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target))
+            elif update_target == 18:
+                db_channel.ep_inc_pct = float(target)
+                db_channel.save()
+                messages.success(request, 'Emergency increase % for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target))
+            elif update_target == 19:
+                db_channel.ep_cooldown = int(target)
+                db_channel.save()
+                messages.success(request, 'Emergency cooldown for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target) + ' min')
+            elif update_target == 20:
+                db_channel.ep_live_threshold = int(target)
+                db_channel.save()
+                messages.success(request, 'Live threshold for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target) + '%')
+            elif update_target == 21:
+                db_channel.ep_live_inc_pct = float(target)
+                db_channel.save()
+                messages.success(request, 'Live increase % for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target))
             else:
                 messages.error(request, 'Invalid target code. Please try again.')
         else:

--- a/htlc_stream.py
+++ b/htlc_stream.py
@@ -2,12 +2,15 @@ import django
 from datetime import datetime
 from gui.lnd_deps import router_pb2 as lnr
 from gui.lnd_deps import router_pb2_grpc as lnrouter
+from gui.lnd_deps import lightning_pb2 as ln
+from gui.lnd_deps import lightning_pb2_grpc as lnrpc
 from gui.lnd_deps.lnd_connect import lnd_connect
 from os import environ
 from time import sleep
 environ['DJANGO_SETTINGS_MODULE'] = 'lndg.settings'
 django.setup()
 from gui.models import Channels, FailedHTLCs
+from jobs_emergency import emergency_forward_check
 
 def main():
     while True:
@@ -15,6 +18,7 @@ def main():
             print(f"{datetime.now().strftime('%c')} : [HTLC] : Starting failed HTLC stream...")
             connection = lnd_connect()
             routerstub = lnrouter.RouterStub(connection)
+            lightning_stub = lnrpc.LightningStub(connection)
             all_forwards = {}
             for response in routerstub.SubscribeHtlcEvents(lnr.SubscribeHtlcEventsRequest()):
                 if response.event_type == 3 and str(response.link_fail_event) != '':
@@ -39,7 +43,8 @@ def main():
                     # Delete forward_event
                     key = str(response.incoming_channel_id) + str(response.outgoing_channel_id) + str(response.incoming_htlc_id) + str(response.outgoing_htlc_id)
                     if key in all_forwards.keys():
-                            del all_forwards[key]
+                        del all_forwards[key]
+                        emergency_forward_check(lightning_stub, response.outgoing_channel_id)
                 elif response.event_type == 3 and str(response.forward_fail_event) == '':
                     key = str(response.incoming_channel_id) + str(response.outgoing_channel_id) + str(response.incoming_htlc_id) + str(response.outgoing_htlc_id)
                     if key in all_forwards.keys():

--- a/jobs.py
+++ b/jobs.py
@@ -16,6 +16,7 @@ django.setup()
 from gui.models import Payments, PaymentHops, Invoices, Forwards, Channels, Peers, Onchain, Closures, Resolutions, PendingHTLCs, LocalSettings, FailedHTLCs, Autofees, InboundFeeLog, PendingChannels, HistFailedHTLC, PeerEvents
 from gui.node_cache import get_node_info_cached
 import af
+from jobs_emergency import emergency_forward_check
 
 CHANNEL_UPDATE_FIELDS = [
     'remote_pubkey', 'short_chan_id', 'funding_txid', 'output_index', 'capacity',
@@ -248,6 +249,7 @@ def update_forwards(stub):
             inbound_fee=round(in_fee_msat / 1000, 3)
         ))
     Forwards.objects.bulk_create(new_forwards)
+    emergency_forward_check(stub, [f.chan_id_out for f in forwards])
 
 def disconnectpeer(stub, peer):
     try:
@@ -834,6 +836,43 @@ def auto_maxhtlc_job(stub):
             ch.maxhtlc_updated = datetime.now()
             ch.save()
 
+def emergency_fee_job(stub):
+    if LocalSettings.objects.filter(key='EP-Enabled').exists():
+        if int(LocalSettings.objects.filter(key='EP-Enabled')[0].value) == 0:
+            return
+    else:
+        LocalSettings(key='EP-Enabled', value='0').save()
+        return
+    default_target = int(LocalSettings.objects.filter(key='EP-DefaultTarget').first().value)
+    default_inc = float(LocalSettings.objects.filter(key='EP-IncreasePct').first().value)
+    default_cooldown = int(LocalSettings.objects.filter(key='EP-Cooldown').first().value)
+    channels = Channels.objects.filter(is_open=True, ep_enabled=True)
+    for ch in channels:
+        target = ch.ep_target if ch.ep_target is not None else default_target
+        inc_pct = ch.ep_inc_pct if ch.ep_inc_pct is not None else default_inc
+        cooldown = ch.ep_cooldown if ch.ep_cooldown is not None else default_cooldown
+        percent = (ch.local_balance + ch.pending_outbound) * 100 / ch.capacity if ch.capacity else 0
+        if percent < target:
+            if not ch.ep_updated or (datetime.now() - ch.ep_updated).total_seconds() >= cooldown * 60:
+                new_rate = int(ch.local_fee_rate * (1 + inc_pct/100))
+                channel_point = ln.ChannelPoint()
+                channel_point.funding_txid_bytes = bytes.fromhex(ch.funding_txid)
+                channel_point.funding_txid_str = ch.funding_txid
+                channel_point.output_index = ch.output_index
+                try:
+                    stub.UpdateChannelPolicy(ln.PolicyUpdateRequest(
+                        chan_point=channel_point,
+                        base_fee_msat=ch.local_base_fee,
+                        fee_rate=(new_rate/1000000),
+                        time_lock_delta=ch.local_cltv))
+                    Autofees(chan_id=ch.chan_id, peer_alias=ch.alias, setting='EP', old_value=ch.local_fee_rate, new_value=new_rate).save()
+                    ch.local_fee_rate = new_rate
+                    ch.fees_updated = datetime.now()
+                    ch.ep_updated = datetime.now()
+                    ch.save()
+                except Exception as e:
+                    print(f"{datetime.now().strftime('%c')} : [Data] : Error updating emergency fee for {ch.chan_id}: {str(e)}")
+
 
 def agg_htlcs(target_htlcs, category):
     try:
@@ -880,6 +919,7 @@ def main():
             update_peers(stub)
             refresh_peer_aliases(stub)
             update_channels(stub)
+            emergency_fee_job(stub)
             update_invoices(stub)
             update_payments(stub)
             update_forwards(stub)

--- a/jobs_emergency.py
+++ b/jobs_emergency.py
@@ -1,0 +1,80 @@
+import django
+from datetime import datetime
+from os import environ
+
+from gui.lnd_deps import lightning_pb2 as ln
+
+environ['DJANGO_SETTINGS_MODULE'] = 'lndg.settings'
+django.setup()
+
+from gui.models import Channels, LocalSettings, Autofees
+
+
+def emergency_forward_check(stub, chan_ids):
+    """Apply emergency fee increases after a forward settles."""
+    if not isinstance(chan_ids, list):
+        chan_ids = [chan_ids]
+
+    if LocalSettings.objects.filter(key='EP-Enabled').exists():
+        if int(LocalSettings.objects.filter(key='EP-Enabled')[0].value) == 0:
+            return
+    else:
+        LocalSettings(key='EP-Enabled', value='0').save()
+        return
+
+    default_threshold = int(LocalSettings.objects.filter(key='EP-LiveThreshold').first().value)
+    default_inc = float(LocalSettings.objects.filter(key='EP-LiveIncreasePct').first().value)
+
+    db_channels = Channels.objects.filter(chan_id__in=chan_ids, ep_enabled=True)
+    if not db_channels:
+        return
+
+    live_map = {
+        ch.chan_id: ch
+        for ch in stub.ListChannels(ln.ListChannelsRequest()).channels
+        if ch.chan_id in chan_ids
+    }
+
+    for db_ch in db_channels:
+        live_ch = live_map.get(db_ch.chan_id)
+        if not live_ch:
+            continue
+
+        threshold = db_ch.ep_live_threshold if db_ch.ep_live_threshold is not None else default_threshold
+        inc_pct = db_ch.ep_live_inc_pct if db_ch.ep_live_inc_pct is not None else default_inc
+
+        pending_out = sum(h.amount for h in live_ch.pending_htlcs if not h.incoming)
+        percent = (live_ch.local_balance + pending_out) * 100 / live_ch.capacity if live_ch.capacity else 0
+
+        if percent < threshold:
+            new_rate = int(db_ch.local_fee_rate * (1 + inc_pct / 100))
+            channel_point = ln.ChannelPoint(
+                funding_txid_bytes=bytes.fromhex(db_ch.funding_txid),
+                funding_txid_str=db_ch.funding_txid,
+                output_index=db_ch.output_index,
+            )
+            try:
+                stub.UpdateChannelPolicy(
+                    ln.PolicyUpdateRequest(
+                        chan_point=channel_point,
+                        base_fee_msat=db_ch.local_base_fee,
+                        fee_rate=(new_rate / 1_000_000),
+                        time_lock_delta=db_ch.local_cltv,
+                    )
+                )
+                Autofees(
+                    chan_id=db_ch.chan_id,
+                    peer_alias=db_ch.alias,
+                    setting='EP-L',
+                    old_value=db_ch.local_fee_rate,
+                    new_value=new_rate,
+                ).save()
+                db_ch.local_fee_rate = new_rate
+                db_ch.fees_updated = datetime.now()
+                db_ch.ep_updated = datetime.now()
+                db_ch.save()
+            except Exception as e:
+                print(
+                    f"{datetime.now().strftime('%c')} : [Data] : Error updating live emergency fee for {db_ch.chan_id}: {str(e)}"
+                )
+


### PR DESCRIPTION
## Summary
- add emergency fee increase settings and new database fields
- create a settings page to configure emergency fee logic
- implement background logic to bump fees when outbound liquidity falls
- document new settings
