### PR TITLE
Improve weighted ranking for saved routes

### DIFF
--- a/gui/models.py
+++ b/gui/models.py
@@ -1,5 +1,16 @@
 from django.db import models
 from django.utils import timezone
+from django.db.models import (
+    ExpressionWrapper,
+    Value,
+    FloatField,
+)
+from django.db.models.functions import Cast
+
+
+def _is_django_expression(value) -> bool:
+    """Return True if value behaves like a Django expression (e.g., F)."""
+    return hasattr(value, "resolve_expression")
 
 # Create your models here.
 class Payments(models.Model):
@@ -437,8 +448,53 @@ class TradeSales(models.Model):
     sale_limit = models.IntegerField(null=True)
     sale_count = models.IntegerField(default=0)
 
+
 def calc_success_ratio(success_count, failure_count):
+    """Return basic success ratio or an expression for ORM usage."""
+    if _is_django_expression(success_count) or _is_django_expression(failure_count):
+        sc = (
+            Cast(success_count, FloatField())
+            if _is_django_expression(success_count)
+            else Value(float(success_count))
+        )
+        fc = (
+            Cast(failure_count, FloatField())
+            if _is_django_expression(failure_count)
+            else Value(float(failure_count))
+        )
+        numerator = sc + Value(1.0)
+        denominator = sc + fc + Value(2.0)
+        return ExpressionWrapper(numerator / denominator, output_field=FloatField())
     return (success_count + 1) / (success_count + failure_count + 2)
+
+
+def calc_weighted_ratio(success_count, failure_count, weight=10):
+    """Return success ratio weighted by number of attempts."""
+    if (
+        _is_django_expression(success_count)
+        or _is_django_expression(failure_count)
+        or _is_django_expression(weight)
+    ):
+        sc = (
+            Cast(success_count, FloatField())
+            if _is_django_expression(success_count)
+            else Value(float(success_count))
+        )
+        fc = (
+            Cast(failure_count, FloatField())
+            if _is_django_expression(failure_count)
+            else Value(float(failure_count))
+        )
+        wv = weight if _is_django_expression(weight) else Value(float(weight))
+        ratio = calc_success_ratio(sc, fc)
+        total = Cast(sc + fc, FloatField())
+        return ExpressionWrapper(
+            ratio * (total / (total + wv)),
+            output_field=FloatField(),
+        )
+    ratio = calc_success_ratio(success_count, failure_count)
+    total = success_count + failure_count
+    return ratio * (total / (total + weight)) if total + weight else ratio
 
 
 class RebalanceRoute(models.Model):
@@ -457,6 +513,18 @@ class RebalanceRoute(models.Model):
     @property
     def success_ratio(self) -> float:
         return calc_success_ratio(self.success_count, self.failure_count)
+
+    @property
+    def weighted_ratio(self) -> float:
+        """Return weighted ratio, using annotated value when available."""
+        if hasattr(self, "_weighted_ratio"):
+            return self._weighted_ratio
+        return calc_weighted_ratio(self.success_count, self.failure_count)
+
+    @weighted_ratio.setter
+    def weighted_ratio(self, value: float):
+        # allow QuerySet.annotate() to set this value without error
+        self._weighted_ratio = value
 
     class Meta:
         app_label = 'gui'

--- a/gui/serializers.py
+++ b/gui/serializers.py
@@ -242,6 +242,7 @@ class FailedHTLCSerializer(serializers.HyperlinkedModelSerializer):
 class RebalanceRouteSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
     success_ratio = serializers.ReadOnlyField()
+    weighted_ratio = serializers.ReadOnlyField()
     last_failure = serializers.ReadOnlyField()
     target_alias = serializers.CharField(read_only=True)
     outgoing_alias = serializers.CharField(read_only=True)

--- a/gui/templates/rebalance_routes.html
+++ b/gui/templates/rebalance_routes.html
@@ -38,6 +38,7 @@
         <th>Target Pubkey</th>
         <th>Outgoing Chan ID</th>
         <th>Success Ratio</th>
+        <th>Weighted Ratio</th>
         <th>Successes</th>
         <th>Failures</th>
         <th>Last Success</th>
@@ -59,7 +60,7 @@ async function loadRoutes(){
       const tb = (b.target_alias || b.target_pubkey).toLowerCase();
       if(ta < tb) return -1;
       if(ta > tb) return 1;
-      return b.success_ratio - a.success_ratio;
+      return b.weighted_ratio - a.weighted_ratio;
     });
     res.results.forEach(r => {
       const row = table.insertRow();
@@ -68,6 +69,7 @@ async function loadRoutes(){
       row.insertCell().innerText = (r.target_alias ? r.target_alias + ' - ' : '') + r.target_pubkey;
       row.insertCell().innerText = (r.outgoing_alias ? r.outgoing_alias + ' - ' : '') + r.outgoing_chan_id;
       row.insertCell().innerText = (r.success_ratio*100).toFixed(1)+'%';
+      row.insertCell().innerText = (r.weighted_ratio*100).toFixed(1)+'%';
       row.insertCell().innerText = r.success_count;
       row.insertCell().innerText = r.failure_count;
       row.insertCell().innerText = r.last_success ? formatDate(r.last_success) : '---';

--- a/gui/views.py
+++ b/gui/views.py
@@ -13,7 +13,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from .forms import *
 from .serializers import *
-from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, InboundFeeLog, PendingChannels, AvoidNodes, PeerEvents, HistFailedHTLC, TradeSales, RebalanceRoute, AllowedTarget, AmbossPeerFees, calc_success_ratio
+from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, InboundFeeLog, PendingChannels, AvoidNodes, PeerEvents, HistFailedHTLC, TradeSales, RebalanceRoute, AllowedTarget, AmbossPeerFees, calc_success_ratio, calc_weighted_ratio
 from gui.node_cache import get_node_info_cached, cache_stats
 from gui.lnd_deps import lightning_pb2 as ln
 from gui.lnd_deps import lightning_pb2_grpc as lnrpc
@@ -3193,9 +3193,10 @@ class RebalanceRouteViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = (
         RebalanceRoute.objects.annotate(
             ratio=calc_success_ratio(F('success_count'), F('failure_count')),
+            weighted_ratio=calc_weighted_ratio(F('success_count'), F('failure_count')),
             target_alias=Subquery(target_alias),
             outgoing_alias=Subquery(outgoing_alias),
-        ).order_by('target_alias', '-ratio')
+        ).order_by('target_alias', '-weighted_ratio')
     )
     serializer_class = RebalanceRouteSerializer
     filterset_fields = {'target_pubkey': ['exact'], 'outgoing_chan_id': ['exact']}

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -23,6 +23,7 @@ from gui.models import (
     Autopilot,
     RebalanceRoute,
     calc_success_ratio,
+    calc_weighted_ratio,
 )
 
 # map standard failure codes and internal details to enum names for clearer logs
@@ -159,8 +160,11 @@ def get_saved_routes(pubkey, chan_ids, limit=10):
             RebalanceRoute.objects
             .filter(target_pubkey=pubkey, outgoing_chan_id__in=chan_ids)
             .filter(Q(last_failure__lt=cutoff) | Q(last_failure__isnull=True))
-            .annotate(ratio=calc_success_ratio(F('success_count'), F('failure_count')))
-            .order_by('-ratio')[:limit]
+            .annotate(
+                ratio=calc_success_ratio(F('success_count'), F('failure_count')),
+                weighted_ratio=calc_weighted_ratio(F('success_count'), F('failure_count')),
+            )
+            .order_by('-weighted_ratio')[:limit]
         )
     except Exception as e:
         print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Error getting saved routes: {str(e)}")


### PR DESCRIPTION
## Summary
- add `calc_weighted_ratio` utility in `models`
- use weighted ratio when sorting saved routes
- expose weighted ratio via API and template
