### PR TITLE
Add AF Fee Limit Protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,15 +331,31 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-LowLiqBoostAR`: When `1`, apply the low-liquidity boost only to channels with Auto-Rebalance enabled; `0` disables the boost entirely.
 - `AF-PeerRateLimit`: Maximum peer oRate (ppm) for applying low-liquidity fee increases. `0` disables this check.
 - `AF-PeerRateCheck`: Enable (`1`) or disable (`0`) the peer oRate limit evaluation.
-- `AF-ExcessLimit`: Outbound liquidity (%) threshold above which the "Excess Liquidity" fee algorithm applies.
+- `AF-ExcessLimit`: Outbound liquidity (%) threshold that triggers automatic fee decreases.
+- `AF-ExcessBoost`: Scaling factor applied to the excess-liquidity decrease step (default: 1).
+- `AF-ExcessBoostOn`: Set to `1` to enable the boost factor; `0` disables it.
 
 ### Auto-Fees Notes
 
 1.  AF adjustments occur only if `AF-UpdateHours` have passed since the last LNDg fee update for that channel (fractions are supported).
 2.  Channels below `AF-LowLiqLimit`% outbound liquidity may see fee increases based on failed HTLCs and incoming flow. When `AF-PeerRateCheck` is enabled, increases only occur if the peer's oRate is below `AF-PeerRateLimit`.
-3.  Channels above `AF-ExcessLimit`% outbound liquidity may see fee decreases based on lack of flow or assisted revenue.
+3.  Channels above `AF-ExcessLimit`% outbound liquidity always decrease by 1&nbsp;ppm (scaled by `AF-ExcessBoost` when enabled).
 4.  Channels between these limits adjust based on overall flow patterns.
 5.  View AF change history in the "Autofees" tab.
+
+## Fee Limit Protection (FLP)
+
+Ensure AutoFee never drops outbound rates below recent rebalancing costs.
+
+- `FLP-Enabled`: Global switch for enforcing the fee floor.
+- `FLP-Safety`: Safety distance in ppm subtracted from the average cost.
+- `FLP-Lookback`: Number of successful rebalance payments to average.
+
+Enable the "Update Channels" option on the Fee Limit Protection page to apply
+`FLP-Enabled` and `FLP-Safety` to all channels at once.
+
+Each channel has its own `flp_enabled` flag and `flp_safety` value. The floor is
+`avg_cost - (FLP-Safety + flp_safety)` if enabled.
 
 ## Emergency Fee Increases
 

--- a/af.py
+++ b/af.py
@@ -5,13 +5,30 @@ from os import environ
 from pandas import DataFrame, Series
 environ['DJANGO_SETTINGS_MODULE'] = 'lndg.settings'
 django.setup()
-from gui.models import Forwards, Channels, LocalSettings, FailedHTLCs
+from gui.models import Forwards, Channels, LocalSettings, FailedHTLCs, Payments
 from utils import get_local_setting
 
 def main(channels):
     channels_df = DataFrame.from_records(channels.values())
     if channels_df.shape[0] == 0:
         return DataFrame()
+    lookback = get_local_setting('FLP-Lookback', 10, int)
+    flp_enabled_global = get_local_setting('FLP-Enabled', '0', str) == '1'
+    flp_safety_global = get_local_setting('FLP-Safety', 0, int)
+    avg_costs = {}
+    for ch in channels:
+        payments = (
+            Payments.objects.filter(status=2, rebal_chan=ch.chan_id)
+            .order_by('-creation_date')[:lookback]
+        )
+        ppm_values = [
+            (p.fee * 1000000 / p.value) for p in payments if p.value
+        ]
+        if ppm_values:
+            avg_costs[ch.chan_id] = int(sum(ppm_values) / len(ppm_values))
+        else:
+            avg_costs[ch.chan_id] = None
+    channels_df['avg_rebalance_cost'] = channels_df['chan_id'].map(avg_costs)
     filter_1day = datetime.now() - timedelta(days=1)
     filter_4h = datetime.now() - timedelta(hours=4)
     filter_7day = datetime.now() - timedelta(days=7)
@@ -25,6 +42,8 @@ def main(channels):
     excess_limit = get_local_setting('AF-ExcessLimit', 95, int)
     lowliq_boost = get_local_setting('AF-LowLiqBoost', 1.0, float)
     boost_ar_only = get_local_setting('AF-LowLiqBoostAR', '0', str) == '1'
+    excess_boost = get_local_setting('AF-ExcessBoost', 1.0, float)
+    excess_boost_enabled = get_local_setting('AF-ExcessBoostOn', '0', str) == '1'
     peer_rate_check = get_local_setting('AF-PeerRateCheck', '0', str) == '1'
     peer_rate_limit = get_local_setting('AF-PeerRateLimit', 0, int)
     if lowliq_limit >= excess_limit:
@@ -216,23 +235,32 @@ def main(channels):
             return (5 * multiplier) if (row['total_failed_out_1day'] > failed_htlc_limit and
                                     row['total_amt_routed_in_1day'] == 0) else 0
         elif row['overall_out_percent'] >= excess_limit:
-            if row['total_amt_routed_in_4h'] + row['total_amt_routed_out_4h'] < 1000:
-                return -1  # kleiner Schritt nach unten (1 ppm), Kanal voll aber wenig Traffic
-            else:
-                return 0
+            adj = -1
+            if excess_boost_enabled:
+                adj = int(adj * excess_boost)
+            return adj
         elif row['overall_out_percent'] < excess_limit:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
-                return -3 * multiplier
+                adj = -3 * multiplier
+                if excess_boost_enabled:
+                    adj = int(adj * excess_boost)
+                return adj
             elif row['group_net_routed_7day'] > 1:
                 return (2 * multiplier) * (1 + row['group_net_routed_7day'])
             else:
                 return 0
         else:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
-                return -5 * multiplier
+                adj = -5 * multiplier
+                if excess_boost_enabled:
+                    adj = int(adj * excess_boost)
+                return adj
             elif (row['group_net_routed_7day'] < 0 and
                 row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10):
-                return -5 * multiplier
+                adj = -5 * multiplier
+                if excess_boost_enabled:
+                    adj = int(adj * excess_boost)
+                return adj
             else:
                 return 0
 
@@ -242,6 +270,22 @@ def main(channels):
     channels_df['new_rate'] = channels_df['local_fee_rate'] + channels_df['adjustment']
     channels_df['new_rate'] = (channels_df['new_rate'] / increment).round(0) * increment
     channels_df['new_rate'] = channels_df['new_rate'].clip(min_rate, max_rate)
+    def compute_cost_floor(row):
+        if not flp_enabled_global or not row.get('flp_enabled'):
+            return 0
+        avg_cost = row.get('avg_rebalance_cost')
+        if avg_cost is None:
+            return 0
+        safety = flp_safety_global + row.get('flp_safety', 0)
+        return max(avg_cost - safety, 0)
+
+    channels_df['cost_floor'] = (
+        channels_df.apply(compute_cost_floor, axis=1)
+        .round(0)
+        .clip(upper=max_rate)
+        .fillna(0)
+    )
+    channels_df['new_rate'] = channels_df[['new_rate', 'cost_floor']].max(axis=1)
     channels_df['adjustment'] = channels_df['new_rate'] - channels_df['local_fee_rate']
 
     # Compute new inbound rates

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -67,6 +67,11 @@ class AutoFeesForm(AutoRebalanceForm):
     af_peer_rate_limit = forms.IntegerField(label='af_peer_rate_limit', required=False)
     af_peer_rate_check = forms.IntegerField(label='af_peer_rate_check', required=False)
     af_excess = forms.IntegerField(label='af_excess', required=False)
+    af_excessboost = forms.FloatField(label='af_excessboost', required=False)
+    af_excessboost_on = forms.IntegerField(label='af_excessboost_on', required=False)
+    flp_enabled = forms.IntegerField(label='flp_enabled', required=False)
+    flp_safety = forms.IntegerField(label='flp_safety', required=False)
+    flp_lookback = forms.IntegerField(label='flp_lookback', required=False)
 
 class GUIForm(AutoFeesForm):
     gui_graphLinks = forms.CharField(label='gui_graphLinks', required=False)
@@ -116,6 +121,8 @@ updates_channel_codes = [
     (19, 'ep_cooldown'),
     (20, 'ep_live_threshold'),
     (21, 'ep_live_inc_pct'),
+    (22, 'flp_enabled'),
+    (23, 'flp_safety'),
 ]
 
 class UpdateChannel(forms.Form):

--- a/gui/migrations/0053_flp_enabled.py
+++ b/gui/migrations/0053_flp_enabled.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('gui', '0052_ep_channel_settings'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channels',
+            name='flp_enabled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='channels',
+            name='flp_safety',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/gui/models.py
+++ b/gui/models.py
@@ -153,6 +153,8 @@ class Channels(models.Model):
     ep_cooldown = models.IntegerField(default=10)
     ep_live_threshold = models.IntegerField(default=40)
     ep_live_inc_pct = models.FloatField(default=5)
+    flp_enabled = models.BooleanField(default=False)
+    flp_safety = models.IntegerField(default=0)
     ep_updated = models.DateTimeField(default=timezone.now)
     fees_updated = models.DateTimeField(default=timezone.now)
     auto_fees = models.BooleanField()

--- a/gui/templates/af_fee_limit.html
+++ b/gui/templates/af_fee_limit.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %} {{ block.super }} - AF Fee Limit Protection{% endblock %}
+{% block content %}
+{% load humanize %}
+<div class="w3-container w3-padding-small">
+  <h2>AF Fee Limit Protection</h2>
+  <div class="w3-container w3-padding-small" style="overflow-x: auto">
+    <table class="w3-table-all w3-centered w3-hoverable">
+      <thead>
+        <tr>
+          <th>Channel ID</th>
+          <th>Peer Alias</th>
+          <th>Avg Rebalancing Cost (PPM)</th>
+          <th>Safety Distance</th>
+          <th>FLP Enabled</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for ch in channels %}
+        <tr>
+          <td><a href="/channel?={{ ch.chan_id }}" target="_blank">{{ ch.chan_id }}</a></td>
+          <td>{{ ch.alias }}</td>
+          <td>{% if ch.avg_ppm is not None %}{{ ch.avg_ppm|intcomma }}{% else %}N/A{% endif %}</td>
+          <td>
+            <form action="/update_channel/" method="post" style="margin:0">
+              {% csrf_token %}
+              <input type="number" style="width:70px;text-align:center" name="target" value="{{ ch.flp_safety }}" min="0" onkeydown="if(event.key==='Enter'){this.form.submit();}">
+              <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+              <input type="hidden" name="update_target" value="23">
+            </form>
+          </td>
+          <td>
+            <form action="/update_channel/" method="post" style="margin:0">
+              {% csrf_token %}
+              <input class="w3-check" type="checkbox" onchange="this.form.submit()" {% if ch.flp_enabled %}checked{% endif %}>
+              <input type="hidden" name="chan_id" value="{{ ch.chan_id }}">
+              <input type="hidden" name="update_target" value="22">
+              <input type="hidden" name="target" value="0">
+            </form>
+          </td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="5">No channels found</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% include 'local_settings.html' with settings=local_settings title='Fee Limit Protection' %}
+{% endblock %}
+

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -151,6 +151,7 @@
   <a class="w3-bar-item w3-hover-blue" href="/autopilot" target="_blank">Autopilot</a>
   <a class="w3-bar-item w3-hover-blue" href="/autofees" target="_blank">Outbound Fee Log</a>
   <a class="w3-bar-item w3-hover-blue" href="/inbound-fee-log" target="_blank">Inbound Fee Log</a>
+  <a class="w3-bar-item w3-hover-blue" href="/fee-limit-protection" target="_blank">AF Fee Limit Protection</a>
   <a class="w3-bar-item w3-hover-blue" href="/channels" target="_blank">Channel Performance</a>
   <a class="w3-bar-item w3-hover-blue" href="/keysends" target="_blank">Keysends</a>
   <a class="w3-bar-item w3-hover-blue" href="/rebalancing" target="_blank">Rebalancing</a>

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -76,6 +76,7 @@ urlpatterns = [
     path('autopilot/', views.autopilot, name='autopilot'),
     path('autofees/', views.outbound_fee_log, name='outbound-fee-log'),
     path('inbound-fee-log/', views.inbound_fee_log, name='inbound-fee-log'),
+    path('fee-limit-protection/', views.fee_limit_protection, name='fee-limit-protection'),
     path('peerevents', views.peerevents, name='peerevents'),
     path('advanced/', views.advanced, name='advanced'),
     path('advanced_rebalancing', views.advanced_rebalancing, name='advanced-rebalancing'),

--- a/gui/views.py
+++ b/gui/views.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 from secrets import token_bytes
 from trade import create_trade_details
 import af
+from utils import get_local_setting
 
 def graph_links():
     if LocalSettings.objects.filter(key='GUI-GraphLinks').exists():
@@ -2215,6 +2216,27 @@ def inbound_offset(request):
         return redirect('home')
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
+def fee_limit_protection(request):
+    if request.method == 'GET':
+        lookback = get_local_setting('FLP-Lookback', 10, int)
+        channels = Channels.objects.filter(is_open=True, auto_rebalance=True)
+        channel_list = []
+        for ch in channels:
+            payments = Payments.objects.filter(status=2, rebal_chan=ch.chan_id).order_by('-creation_date')[:lookback]
+            ppm_values = [(p.fee * 1000000 / p.value) for p in payments if p.value]
+            avg_ppm = int(sum(ppm_values) / len(ppm_values)) if ppm_values else None
+            channel_list.append({'chan_id': ch.chan_id, 'alias': ch.alias, 'avg_ppm': avg_ppm, 'flp_enabled': ch.flp_enabled, 'flp_safety': ch.flp_safety})
+        context = {
+            'channels': channel_list,
+            'local_settings': get_local_settings('FLP-'),
+            'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
+            'graph_links': graph_links(),
+        }
+        return render(request, 'af_fee_limit.html', context)
+    else:
+        return redirect('home')
+
+@is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def auto_maxhtlc(request):
     if request.method == 'GET':
         channels = Channels.objects.filter(is_open=True).annotate(outbound=F('local_balance') + F('pending_outbound'))
@@ -2493,6 +2515,13 @@ def get_local_settings(*prefixes):
         form.append({'unit': 'ppm', 'form_id': 'af_peer_rate_limit', 'value': 0, 'label': 'Peer oRate Limit', 'id': 'AF-PeerRateLimit', 'title': 'Only raise fees if peer oRate below this limit; 0 disables', 'min':0, 'max':5000})
         form.append({'unit': '', 'form_id': 'af_peer_rate_check', 'value': 0, 'label': 'Peer Rate Check', 'id': 'AF-PeerRateCheck', 'title': 'Enable/Disable peer oRate limit check', 'min':0, 'max':1})
         form.append({'unit': '%', 'form_id': 'af_excess', 'value': 95, 'label': 'AF Excess', 'id': 'AF-ExcessLimit', 'title': 'Limit for running excess liq AF rules (decrease for stagnant channels and those with assisting revenues). Default 95', 'min':0, 'max':100})
+        form.append({'unit': 'x', 'form_id': 'af_excessboost', 'value': 1, 'label': 'AF Excess Boost', 'id': 'AF-ExcessBoost', 'title': 'Multiplier for extra fee drop when liquidity exceeds AF-ExcessLimit. Default 1', 'min':0, 'max':10})
+        form.append({'unit': '', 'form_id': 'af_excessboost_on', 'value': 0, 'label': 'Excess Boost', 'id': 'AF-ExcessBoostOn', 'title': 'Enable/Disable extra decrease for excess liquidity', 'min':0, 'max':1})
+    if 'FLP-' in prefixes:
+        form.append({'unit': '', 'form_id': 'update_channels', 'id': 'update_channels'})
+        form.append({'unit': '', 'form_id': 'flp_enabled', 'value': 0, 'label': 'FLP Enabled', 'id': 'FLP-Enabled', 'title': 'Enable/Disable fee limit protection', 'min':0, 'max':1})
+        form.append({'unit': 'ppm', 'form_id': 'flp_safety', 'value': 0, 'label': 'Safety Distance', 'id': 'FLP-Safety', 'title': 'Subtract this value from avg cost when computing the floor', 'min':0})
+        form.append({'unit': '', 'form_id': 'flp_lookback', 'value': 10, 'label': 'Payments Lookback', 'id': 'FLP-Lookback', 'title': 'Number of recent rebalancing payments to average', 'min':1})
     if 'IO-' in prefixes:
         form.append({'unit': '', 'form_id': 'io_enabled', 'value': 0, 'label': 'Offset Updates', 'id': 'IO-Enabled', 'title': 'Enable/Disable automatic inbound offset updates', 'min':0, 'max':1})
         form.append({'unit': 'hours', 'form_id': 'io_updateHours', 'value': 24, 'label': 'IO Update', 'id': 'IO-UpdateHours', 'title': 'Hours between applying inbound offsets. Fractions allowed. Default 24', 'min':0.01, 'max':100})
@@ -2564,6 +2593,11 @@ def update_settings(request):
                     {'form_id': 'af_peer_rate_limit', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-PeerRateLimit'},
                     {'form_id': 'af_peer_rate_check', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-PeerRateCheck'},
                     {'form_id': 'af_excess', 'value': 95, 'parse': lambda x: int(x),'id': 'AF-ExcessLimit'},
+                    {'form_id': 'af_excessboost', 'value': 1, 'parse': lambda x: float(x),'id': 'AF-ExcessBoost'},
+                    {'form_id': 'af_excessboost_on', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-ExcessBoostOn'},
+                    {'form_id': 'flp_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'FLP-Enabled'},
+                    {'form_id': 'flp_safety', 'value': 0, 'parse': lambda x: int(x),'id': 'FLP-Safety'},
+                    {'form_id': 'flp_lookback', 'value': 10, 'parse': lambda x: int(x),'id': 'FLP-Lookback'},
                     #IO
                     {'form_id': 'io_enabled', 'value': 0, 'parse': lambda x: int(x),'id': 'IO-Enabled'},
                     {'form_id': 'io_updateHours', 'value': 24, 'parse': lambda x: float(x),'id': 'IO-UpdateHours'},
@@ -2616,7 +2650,7 @@ def update_settings(request):
                     db_value.value = value
                     db_value.save()
 
-                    if update_channels and field['id'] in ['AR-Target%', 'AR-Outbound%','AR-Inbound%','AR-MaxCost%','MX-Percent','EP-DefaultTarget','EP-IncreasePct','EP-Cooldown','EP-LiveThreshold','EP-LiveIncreasePct','EP-Enabled']:
+                    if update_channels and field['id'] in ['AR-Target%', 'AR-Outbound%','AR-Inbound%','AR-MaxCost%','MX-Percent','EP-DefaultTarget','EP-IncreasePct','EP-Cooldown','EP-LiveThreshold','EP-LiveIncreasePct','EP-Enabled','FLP-Enabled','FLP-Safety']:
                         if field['id'] == 'AR-Target%':
                             Channels.objects.all().update(ar_amt_target=Round(F('capacity')*(value/100), output_field=IntegerField()))
                         elif field['id'] == 'AR-Outbound%':
@@ -2639,6 +2673,10 @@ def update_settings(request):
                             Channels.objects.all().update(ep_live_inc_pct=value)
                         elif field['id'] == 'EP-Enabled':
                             Channels.objects.all().update(ep_enabled=bool(value))
+                        elif field['id'] == 'FLP-Enabled':
+                            Channels.objects.all().update(flp_enabled=bool(value))
+                        elif field['id'] == 'FLP-Safety':
+                            Channels.objects.all().update(flp_safety=value)
                         messages.success(request, 'All channels ' + field['id'] + ' updated to: ' + str(value))
                     else:
                         messages.success(request, field['id'] + ' updated to: ' + str(value))
@@ -2781,6 +2819,14 @@ def update_channel(request):
                 db_channel.ep_live_inc_pct = float(target)
                 db_channel.save()
                 messages.success(request, 'Live increase % for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(target))
+            elif update_target == 22:
+                db_channel.flp_enabled = not db_channel.flp_enabled
+                db_channel.save()
+                messages.success(request, 'Fee limit protection for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') set to: ' + str(db_channel.flp_enabled))
+            elif update_target == 23:
+                db_channel.flp_safety = int(target)
+                db_channel.save()
+                messages.success(request, 'FLP safety for channel ' + str(db_channel.alias) + ' (' + str(db_channel.chan_id) + ') updated to: ' + str(db_channel.flp_safety))
             else:
                 messages.error(request, 'Invalid target code. Please try again.')
         else:


### PR DESCRIPTION
## Summary
- add lookback setting for AF Fee Limit Protection
- create AF Fee Limit Protection view
- show AF Fee Limit Protection nav link
- wire fee-limit-protection route
- add a logic that doesn allow AF to drop below outboundPPM of a channel and its AR Max Cost rebalancing value
- add AF Excess Boost function and factor
- AF Excess Boost functions respectes FLP Limits
