### PR TITLE
Add flow scaling controls to Autofee

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-MaxRate`: Maximum fee rate (ppm) AF can set.
 - `AF-MinRate`: Minimum fee rate (ppm) AF can set.
 - `AF-Multiplier`: Multiplies the `AF-Increment` for larger fee adjustments.
-- `AF-FlowScale`: Scales flow-based adjustments (0 disables flow scaling).
+- `AF-FlowScale`: Scales flow-based adjustments for both heavy inbound and outbound peers (0 disables flow scaling; effect is capped internally).
 - `AF-MaxStep`: Maximum ppm change allowed per update.
  - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24). This field accepts fractions to run more frequently; multiply by 60 to convert to minutes (e.g. `0.08` ≈ 5 minutes).
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-MinRate`: Minimum fee rate (ppm) AF can set.
 - `AF-Multiplier`: Multiplies the `AF-Increment` for larger fee adjustments.
 - `AF-FlowScale`: Scales flow-based adjustments for both heavy inbound and outbound peers (0 disables flow scaling; effect is capped internally).
+- High-flow peers have their base adjustment reduced by 75% before applying `AF-FlowScale`.
 - `AF-MaxStep`: Maximum ppm change allowed per update.
  - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24). This field accepts fractions to run more frequently; multiply by 60 to convert to minutes (e.g. `0.08` ≈ 5 minutes).
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Customize Auto-Fees (AF) behavior via the settings page:
 - `AF-MaxRate`: Maximum fee rate (ppm) AF can set.
 - `AF-MinRate`: Minimum fee rate (ppm) AF can set.
 - `AF-Multiplier`: Multiplies the `AF-Increment` for larger fee adjustments.
+- `AF-FlowScale`: Scales flow-based adjustments (0 disables flow scaling).
+- `AF-MaxStep`: Maximum ppm change allowed per update.
  - `AF-UpdateHours`: Minimum hours between AF adjustments for a single channel (default: 24). This field accepts fractions to run more frequently; multiply by 60 to convert to minutes (e.g. `0.08` ≈ 5 minutes).
 - `AF-LowLiqLimit`: Outbound liquidity (%) threshold below which the "Low Liquidity" fee algorithm applies.
 - `AF-LowLiqBoost`: Scaling factor applied when liquidity is below `AF-LowLiqLimit` (default: 1).

--- a/af.py
+++ b/af.py
@@ -46,6 +46,8 @@ def main(channels):
     excess_boost_enabled = get_local_setting('AF-ExcessBoostOn', '0', str) == '1'
     peer_rate_check = get_local_setting('AF-PeerRateCheck', '0', str) == '1'
     peer_rate_limit = get_local_setting('AF-PeerRateLimit', 0, int)
+    flow_scale = get_local_setting('AF-FlowScale', 1.0, float)
+    max_step = get_local_setting('AF-MaxStep', 100, int)
     if lowliq_limit >= excess_limit:
         print('Invalid thresholds detected, using defaults...')
         lowliq_limit = 5
@@ -187,25 +189,38 @@ def main(channels):
     ).where(group_df['total_capacity'] > 0, 0)
 
     # Define inbound adjustment calculation function
+    def clamp_step(val):
+        if val > max_step:
+            return max_step
+        if val < -max_step:
+            return -max_step
+        return int(val)
+
     def compute_inbound_adjustment(row):
         if row['overall_out_percent'] <= lowliq_limit:
-            return (-12 * multiplier) if (row['total_failed_out_1day'] > failed_htlc_limit and
-                                    row['total_amt_routed_in_1day'] == 0) else 0
+            adj = (-12 * multiplier) if (
+                row['total_failed_out_1day'] > failed_htlc_limit
+                and row['total_amt_routed_in_1day'] == 0
+            ) else 0
         elif row['overall_out_percent'] < excess_limit:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
-                return 7 * multiplier
+                adj = 7 * multiplier
             elif row['group_net_routed_7day'] > 1:
-                return (-5 * multiplier) * (1 + row['group_net_routed_7day'])
+                scale = 1 + row['group_net_routed_7day'] * flow_scale
+                adj = (-5 * multiplier) * scale
             else:
-                return 0
+                adj = 0
         else:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
-                return 12 * multiplier
-            elif (row['group_net_routed_7day'] < 0 and
-                row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10):
-                return 12 * multiplier
+                adj = 12 * multiplier
+            elif (
+                row['group_net_routed_7day'] < 0
+                and row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10
+            ):
+                adj = 12 * multiplier
             else:
-                return 0
+                adj = 0
+        return clamp_step(adj)
 
     group_df['inbound_adjustment'] = group_df.apply(compute_inbound_adjustment, axis=1)
 
@@ -229,40 +244,45 @@ def main(channels):
             if boost_ar_only and row.get('auto_rebalance'):
                 deficit = max(0, lowliq_limit - row['out_percent'])
                 boost = deficit / max(lowliq_limit, 1) * lowliq_boost
-            return max(1, int(multiplier * boost))
+            return clamp_step(max(1, int(multiplier * boost)))
 
         if row['overall_out_percent'] <= lowliq_limit:
-            return (5 * multiplier) if (row['total_failed_out_1day'] > failed_htlc_limit and
-                                    row['total_amt_routed_in_1day'] == 0) else 0
+            adj = (5 * multiplier) if (
+                row['total_failed_out_1day'] > failed_htlc_limit
+                and row['total_amt_routed_in_1day'] == 0
+            ) else 0
+            return clamp_step(adj)
         elif row['overall_out_percent'] >= excess_limit:
             adj = -1
             if excess_boost_enabled:
                 adj = int(adj * excess_boost)
-            return adj
+            return clamp_step(adj)
         elif row['overall_out_percent'] < excess_limit:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
                 adj = -3 * multiplier
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
-                return adj
             elif row['group_net_routed_7day'] > 1:
-                return (2 * multiplier) * (1 + row['group_net_routed_7day'])
+                scale = 1 + row['group_net_routed_7day'] * flow_scale
+                adj = (2 * multiplier) * scale
             else:
-                return 0
+                adj = 0
+            return clamp_step(adj)
         else:
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
                 adj = -5 * multiplier
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
-                return adj
-            elif (row['group_net_routed_7day'] < 0 and
-                row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10):
+            elif (
+                row['group_net_routed_7day'] < 0
+                and row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10
+            ):
                 adj = -5 * multiplier
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
-                return adj
             else:
-                return 0
+                adj = 0
+            return clamp_step(adj)
 
     channels_df['adjustment'] = channels_df.apply(compute_outbound_adjustment, axis=1)
 

--- a/af.py
+++ b/af.py
@@ -197,6 +197,8 @@ def main(channels):
     ).where(group_df['total_capacity'] > 0, 0)
 
     # Define inbound adjustment calculation function
+    HIGH_FLOW_FACTOR = 0.25
+
     def clamp_step(val):
         if val > max_step:
             return max_step
@@ -216,7 +218,7 @@ def main(channels):
             elif row['group_net_routed_7day'] > 1:
                 flow = clamp_flow(row['group_net_routed_7day'])
                 scale = 1 + flow * flow_scale
-                adj = (-5 * multiplier) * scale
+                adj = (-5 * multiplier * HIGH_FLOW_FACTOR) * scale
             else:
                 adj = 0
         else:
@@ -228,7 +230,7 @@ def main(channels):
             ):
                 flow = abs(clamp_flow(row['group_net_routed_7day']))
                 scale = 1 + flow * flow_scale
-                adj = 12 * multiplier * scale
+                adj = 12 * multiplier * HIGH_FLOW_FACTOR * scale
             else:
                 adj = 0
         return clamp_step(adj)
@@ -276,7 +278,7 @@ def main(channels):
             elif abs(row['group_net_routed_7day']) > 1:
                 flow = clamp_flow(row['group_net_routed_7day'])
                 scale = 1 + abs(flow) * flow_scale
-                base = 2 * multiplier if flow > 0 else -5 * multiplier
+                base = (2 * multiplier if flow > 0 else -5 * multiplier) * HIGH_FLOW_FACTOR
                 adj = base * scale
             else:
                 adj = 0
@@ -292,7 +294,7 @@ def main(channels):
             ):
                 flow = abs(clamp_flow(row['group_net_routed_7day']))
                 scale = 1 + flow * flow_scale
-                adj = -5 * multiplier
+                adj = -5 * multiplier * HIGH_FLOW_FACTOR
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
                 adj *= scale

--- a/af.py
+++ b/af.py
@@ -48,6 +48,14 @@ def main(channels):
     peer_rate_limit = get_local_setting('AF-PeerRateLimit', 0, int)
     flow_scale = get_local_setting('AF-FlowScale', 1.0, float)
     max_step = get_local_setting('AF-MaxStep', 100, int)
+    MAX_NET_FLOW = 3
+
+    def clamp_flow(val):
+        if val > MAX_NET_FLOW:
+            return MAX_NET_FLOW
+        if val < -MAX_NET_FLOW:
+            return -MAX_NET_FLOW
+        return val
     if lowliq_limit >= excess_limit:
         print('Invalid thresholds detected, using defaults...')
         lowliq_limit = 5
@@ -206,7 +214,8 @@ def main(channels):
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
                 adj = 7 * multiplier
             elif row['group_net_routed_7day'] > 1:
-                scale = 1 + row['group_net_routed_7day'] * flow_scale
+                flow = clamp_flow(row['group_net_routed_7day'])
+                scale = 1 + flow * flow_scale
                 adj = (-5 * multiplier) * scale
             else:
                 adj = 0
@@ -214,10 +223,12 @@ def main(channels):
             if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
                 adj = 12 * multiplier
             elif (
-                row['group_net_routed_7day'] < 0
+                row['group_net_routed_7day'] < -1
                 and row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10
             ):
-                adj = 12 * multiplier
+                flow = abs(clamp_flow(row['group_net_routed_7day']))
+                scale = 1 + flow * flow_scale
+                adj = 12 * multiplier * scale
             else:
                 adj = 0
         return clamp_step(adj)
@@ -262,9 +273,11 @@ def main(channels):
                 adj = -3 * multiplier
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
-            elif row['group_net_routed_7day'] > 1:
-                scale = 1 + row['group_net_routed_7day'] * flow_scale
-                adj = (2 * multiplier) * scale
+            elif abs(row['group_net_routed_7day']) > 1:
+                flow = clamp_flow(row['group_net_routed_7day'])
+                scale = 1 + abs(flow) * flow_scale
+                base = 2 * multiplier if flow > 0 else -5 * multiplier
+                adj = base * scale
             else:
                 adj = 0
             return clamp_step(adj)
@@ -274,12 +287,15 @@ def main(channels):
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
             elif (
-                row['group_net_routed_7day'] < 0
+                row['group_net_routed_7day'] < -1
                 and row['total_revenue_assist_7day'] > row['total_revenue_7day'] * 10
             ):
+                flow = abs(clamp_flow(row['group_net_routed_7day']))
+                scale = 1 + flow * flow_scale
                 adj = -5 * multiplier
                 if excess_boost_enabled:
                     adj = int(adj * excess_boost)
+                adj *= scale
             else:
                 adj = 0
             return clamp_step(adj)

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -59,6 +59,8 @@ class AutoFeesForm(AutoRebalanceForm):
     af_minRate = forms.IntegerField(label='af_minRate', required=False)
     af_increment = forms.IntegerField(label='af_increment', required=False)
     af_multiplier = forms.IntegerField(label='af_multiplier', required=False)
+    af_flow_scale = forms.FloatField(label='af_flow_scale', required=False)
+    af_maxstep = forms.IntegerField(label='af_maxstep', required=False)
     af_failedHTLCs = forms.IntegerField(label='af_failedHTLCs', required=False)
     af_updateHours = forms.FloatField(label='af_updateHours', required=False)
     af_lowliq = forms.IntegerField(label='af_lowliq', required=False)

--- a/gui/views.py
+++ b/gui/views.py
@@ -2507,6 +2507,8 @@ def get_local_settings(*prefixes):
         form.append({'unit': 'ppm', 'form_id': 'af_minRate', 'value': 0, 'label': 'AF Min Rate', 'id': 'AF-MinRate', 'title': 'Minimum Rate that can be adjusted to. Default 0', 'min':0, 'max':5000})
         form.append({'unit': 'ppm', 'form_id': 'af_increment', 'value': 5, 'label': 'AF Increment', 'id': 'AF-Increment', 'title': 'Target fee rate will always be a multiple of this value. Default 5', 'min':1, 'max':100})
         form.append({'unit': 'x', 'form_id': 'af_multiplier', 'value': 5, 'label': 'AF Multiplier', 'id': 'AF-Multiplier', 'title': 'Multiplier to be applied to Auto-Fee adjustments. Default 5', 'min':1, 'max':100})
+        form.append({'unit': 'x', 'form_id': 'af_flow_scale', 'value': 1.0, 'label': 'Flow Scale', 'id': 'AF-FlowScale', 'title': 'Scale flow-based adjustments; 0 disables flow factor', 'min':0})
+        form.append({'unit': 'ppm', 'form_id': 'af_maxstep', 'value': 100, 'label': 'Max Step', 'id': 'AF-MaxStep', 'title': 'Maximum change allowed per update', 'min':1})
         form.append({'unit': '', 'form_id': 'af_failedHTLCs', 'value': 25, 'label': 'AF FailedHTLCs', 'id': 'AF-FailedHTLCs', 'title': 'Failed HTLCs required since last fee update to trigger a fee increase (when chan liq% is below AR-LowLiq). Default 25', 'min':1, 'max':100})
         form.append({'unit': 'hours', 'form_id': 'af_updateHours', 'value': 24, 'label': 'AF Update', 'id': 'AF-UpdateHours', 'title': 'Minimum number of hours between fee updates for an individual channel. Default 24', 'min':0.01, 'max':100})
         form.append({'unit': '%', 'form_id': 'af_lowliq', 'value': 15, 'label': 'AF LowLiq', 'id': 'AF-LowLiqLimit', 'title': 'Limit for running low liq AF rules (increase when failed htlcs + no inbound). Default 15', 'min':0, 'max':100})
@@ -2584,8 +2586,10 @@ def update_settings(request):
                     {'form_id': 'af_maxRate', 'value': 2500, 'parse': lambda x: int(x),'id': 'AF-MaxRate'},
                     {'form_id': 'af_minRate', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-MinRate'},
                     {'form_id': 'af_increment', 'value': 5, 'parse': lambda x: int(x),'id': 'AF-Increment'},
-                    {'form_id': 'af_multiplier', 'value': 5, 'parse': lambda x: int(x),'id': 'AF-Multiplier'},
-                    {'form_id': 'af_failedHTLCs', 'value': 25, 'parse': lambda x: int(x),'id': 'AF-FailedHTLCs'},
+                     {'form_id': 'af_multiplier', 'value': 5, 'parse': lambda x: int(x),'id': 'AF-Multiplier'},
+                     {'form_id': 'af_flow_scale', 'value': 1.0, 'parse': lambda x: float(x),'id': 'AF-FlowScale'},
+                     {'form_id': 'af_maxstep', 'value': 100, 'parse': lambda x: int(x),'id': 'AF-MaxStep'},
+                     {'form_id': 'af_failedHTLCs', 'value': 25, 'parse': lambda x: int(x),'id': 'AF-FailedHTLCs'},
                     {'form_id': 'af_updateHours', 'value': 24, 'parse': lambda x: float(x),'id': 'AF-UpdateHours'},
                     {'form_id': 'af_lowliq', 'value': 15, 'parse': lambda x: int(x),'id': 'AF-LowLiqLimit'},
                     {'form_id': 'af_lowliqboost', 'value': 1, 'parse': lambda x: float(x),'id': 'AF-LowLiqBoost'},


### PR DESCRIPTION
## Summary
- add `AF-FlowScale` and `AF-MaxStep` settings for auto-fee
- cap adjustments with `max_step` and scale flow impact
- expose new settings in forms and admin views
- document settings in README
