### PR TITLE
Add alias cache helper and refactor alias lookups

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -11,10 +11,10 @@ from gui.lnd_deps.lnd_connect import get_shared_channel, close_shared_channel
 from lndg import settings
 from os import environ
 from requests import get
+from functools import lru_cache
 environ['DJANGO_SETTINGS_MODULE'] = 'lndg.settings'
 django.setup()
 from gui.models import Payments, PaymentHops, Invoices, Forwards, Channels, Peers, Onchain, Closures, Resolutions, PendingHTLCs, LocalSettings, FailedHTLCs, Autofees, InboundFeeLog, PendingChannels, HistFailedHTLC, PeerEvents
-from gui.node_cache import get_node_info_cached
 import af
 from jobs_emergency import emergency_forward_check
 
@@ -33,6 +33,20 @@ CHANNEL_UPDATE_FIELDS = [
     'ar_out_target', 'ar_max_cost', 'ar_source', 'ar_source_ppm_diff',
     'fees_updated', 'auto_fees', 'notes'
 ]
+
+_ALIAS_STUB = None
+
+
+@lru_cache(maxsize=5000)
+def _alias_for(pub_key):
+    if _ALIAS_STUB is None:
+        return ''
+    try:
+        return _ALIAS_STUB.GetNodeInfo(
+            ln.NodeInfoRequest(pub_key=pub_key, include_channels=False)
+        ).node.alias
+    except Exception:
+        return ''
 
 
 def apply_channel_defaults(ch):
@@ -75,6 +89,13 @@ def apply_channel_defaults(ch):
 
 
 def update_payments(stub):
+    global _ALIAS_STUB
+    if _ALIAS_STUB is not stub:
+        _ALIAS_STUB = stub
+        try:
+            _alias_for.cache_clear()
+        except Exception:
+            pass
     self_pubkey = stub.GetInfo(ln.GetInfoRequest()).identity_pubkey
     inflight_payments = Payments.objects.filter(status=1).order_by('index')
     for payment in inflight_payments:
@@ -163,10 +184,7 @@ def update_payment(stub, payment, self_pubkey):
                 total_hops = len(hops)
                 for hop in hops:
                     hop_count += 1
-                    try:
-                        alias = get_node_info_cached(hop.pub_key, stub).node.alias
-                    except Exception:
-                        alias = ''
+                    alias = _alias_for(hop.pub_key)
                     fee = hop.fee_msat/1000
                     if hop_count == total_hops:
                         # Add additional HTLC information in last hop alias
@@ -223,9 +241,8 @@ def update_invoice(stub, invoice, db_invoice):
                     print(f"{datetime.now().strftime('%c')} : [Data] : Unable to validate signature on invoice: {invoice.r_hash.hex()}")
                     valid = False
                 sender = records[34349339].hex() if valid == True else None
-                try:
-                    sender_alias = get_node_info_cached(sender, stub).node.alias if sender is not None else None
-                except Exception:
+                sender_alias = _alias_for(sender) if sender is not None else None
+                if sender_alias == '':
                     sender_alias = None
             else:
                 sender = None
@@ -328,10 +345,7 @@ def update_channels(stub):
                 db_channel.alias = peer_alias
         else:
             is_new = True
-            try:
-                alias = get_node_info_cached(channel.remote_pubkey, stub).node.alias
-            except Exception:
-                alias = ''
+            alias = _alias_for(channel.remote_pubkey)
             channel_point = channel.channel_point
             txid, index = channel_point.split(':')
             db_channel = Channels(
@@ -588,19 +602,13 @@ def update_peers(stub):
             db_peer.sat_recv = peer.sat_recv
             db_peer.inbound = peer.inbound
             db_peer.ping_time = round(peer.ping_time/1000)
-            try:
-                alias = get_node_info_cached(peer.pub_key, stub).node.alias
-            except Exception:
-                alias = None
+            alias = _alias_for(peer.pub_key)
             if alias and (not db_peer.alias or db_peer.alias != alias):
                 db_peer.alias = alias
             db_peer.connected = True
             peers_to_update.append(db_peer)
         else:
-            try:
-                alias = get_node_info_cached(peer.pub_key, stub).node.alias
-            except Exception:
-                alias = ''
+            alias = _alias_for(peer.pub_key)
             peers_to_create.append(Peers(pubkey=peer.pub_key, address=peer.address, sat_sent=peer.sat_sent, sat_recv=peer.sat_recv, inbound=peer.inbound, ping_time=round(peer.ping_time/1000), alias=alias, connected=True))
         peer_list.append(peer.pub_key)
     if peers_to_create:
@@ -613,10 +621,7 @@ def refresh_peer_aliases(stub):
     """Refresh aliases for peers without an alias."""
     peers = Peers.objects.filter(Q(alias__isnull=True) | Q(alias=''))
     for peer in peers:
-        try:
-            alias = get_node_info_cached(peer.pubkey, stub).node.alias
-        except Exception:
-            alias = None
+        alias = _alias_for(peer.pubkey)
         if alias:
             peer.alias = alias
             peer.save()
@@ -686,7 +691,9 @@ def reconnect_peers(stub):
                         print(f"{datetime.now().strftime('%c')} : [Data] : Inactive channel is still connected to peer, disconnecting peer {peer.alias} {inactive_peer}")
                         disconnectpeer(stub, peer)
                     try:
-                        node = get_node_info_cached(inactive_peer, stub).node
+                        node = stub.GetNodeInfo(
+                            ln.NodeInfoRequest(pub_key=inactive_peer, include_channels=False)
+                        ).node
                         host = node.addresses[0].addr
                     except Exception as e:
                         print(f"{datetime.now().strftime('%c')} : [Data] : Unable to find node info on graph, using last known value for {peer.alias} {peer.pubkey} at {peer.address}: {str(e)}")

--- a/jobs.py
+++ b/jobs.py
@@ -105,28 +105,40 @@ def update_payments(stub):
         ).payments
         if not payments:
             break
+
+        # Identify which hashes on this page are truly new
+        page_hashes = [p.payment_hash for p in payments]
+        existing_hashes = set(Payments.objects.filter(payment_hash__in=page_hashes).values_list('payment_hash', flat=True))
+        new_hashes = set(page_hashes) - existing_hashes
+
         new_payments = []
         for payment in payments:
-            try:
-                new_payments.append(
-                    Payments(
-                        creation_date=datetime.fromtimestamp(payment.creation_date),
-                        payment_hash=payment.payment_hash,
-                        value=round(payment.value_msat/1000, 3),
-                        fee=round(payment.fee_msat/1000, 3),
-                        status=payment.status,
-                        index=payment.payment_index
+            if payment.payment_hash in new_hashes:
+                try:
+                    new_payments.append(
+                        Payments(
+                            creation_date=datetime.fromtimestamp(payment.creation_date),
+                            payment_hash=payment.payment_hash,
+                            value=round(payment.value_msat/1000, 3),
+                            fee=round(payment.fee_msat/1000, 3),
+                            status=payment.status,
+                            index=payment.payment_index
+                        )
                     )
-                )
-            except Exception as e:
-                print(f"{datetime.now().strftime('%c')} : [Data] : Error preparing {getattr(payment, 'payment_hash', '')}: {str(e)}")
+                except Exception as e:
+                    print(f"{datetime.now().strftime('%c')} : [Data] : Error preparing {getattr(payment, 'payment_hash', '')}: {str(e)}")
+
         if new_payments:
             try:
                 Payments.objects.bulk_create(new_payments, ignore_conflicts=True, batch_size=1000)
             except Exception as e:
                 print(f"{datetime.now().strftime('%c')} : [Data] : Error bulk inserting payments: {str(e)}")
+
+        # Enrich only new rows or still incomplete/in-flight ones
         for payment in payments:
-            update_payment(stub, payment, self_pubkey)
+            if (payment.payment_hash in new_hashes) or (payment.status in (0, 1)):
+                update_payment(stub, payment, self_pubkey)
+
         index_offset += len(payments)
         if len(payments) < page_size:
             break

--- a/jobs.py
+++ b/jobs.py
@@ -85,16 +85,51 @@ def update_payments(stub):
         else:
             payment.status = 3
             payment.save()
-    last_index = Payments.objects.aggregate(Max('index'))['index__max'] if Payments.objects.exists() else 0
-    payments = stub.ListPayments(ln.ListPaymentsRequest(include_incomplete=True, index_offset=last_index, max_payments=100)).payments
-    for payment in payments:
-        try:
-            new_payment = Payments(creation_date=datetime.fromtimestamp(payment.creation_date), payment_hash=payment.payment_hash, value=round(payment.value_msat/1000, 3), fee=round(payment.fee_msat/1000, 3), status=payment.status, index=payment.payment_index)
-            new_payment.save()
-        except Exception as e:
-            #Error inserting, try to update instead
-            print(f"{datetime.now().strftime('%c')} : [Data] : Error processing {new_payment}: {str(e)}")
-        update_payment(stub, payment, self_pubkey)
+    # Resume from latest timestamp like PR 404 (use creation_date_start + index_offset), page at 1000
+    latest = Payments.objects.order_by('-creation_date', '-index').first()
+    if latest:
+        start_ts = int(latest.creation_date.timestamp())
+        index_offset = Payments.objects.filter(creation_date=latest.creation_date).count()
+    else:
+        start_ts = int(datetime(2015, 1, 1).timestamp())
+        index_offset = 0
+    page_size = 1000
+    while True:
+        payments = stub.ListPayments(
+            ln.ListPaymentsRequest(
+                include_incomplete=True,
+                creation_date_start=start_ts,
+                index_offset=index_offset,
+                max_payments=page_size
+            )
+        ).payments
+        if not payments:
+            break
+        new_payments = []
+        for payment in payments:
+            try:
+                new_payments.append(
+                    Payments(
+                        creation_date=datetime.fromtimestamp(payment.creation_date),
+                        payment_hash=payment.payment_hash,
+                        value=round(payment.value_msat/1000, 3),
+                        fee=round(payment.fee_msat/1000, 3),
+                        status=payment.status,
+                        index=payment.payment_index
+                    )
+                )
+            except Exception as e:
+                print(f"{datetime.now().strftime('%c')} : [Data] : Error preparing {getattr(payment, 'payment_hash', '')}: {str(e)}")
+        if new_payments:
+            try:
+                Payments.objects.bulk_create(new_payments, ignore_conflicts=True, batch_size=1000)
+            except Exception as e:
+                print(f"{datetime.now().strftime('%c')} : [Data] : Error bulk inserting payments: {str(e)}")
+        for payment in payments:
+            update_payment(stub, payment, self_pubkey)
+        index_offset += len(payments)
+        if len(payments) < page_size:
+            break
 
 def update_payment(stub, payment, self_pubkey):
     db_payment = Payments.objects.filter(payment_hash=payment.payment_hash)[0]


### PR DESCRIPTION
## Summary
- cache node aliases with an LRU helper for up to 5000 entries
- refresh alias cache when payment stub changes
- use alias helper across payment and invoice updates and remove node cache import
