### PR TITLE
Allow positive inbound fee configuration

### DIFF
--- a/gui/templates/advanced.html
+++ b/gui/templates/advanced.html
@@ -26,14 +26,14 @@
         <td title="Update all channel inbound fee rates">
           <form action="/update_setting/" method="post">
             {% csrf_token %}
-            <input data-tag="inbound" style="text-align:center" id="value" type="number" min="-100000" max="0" name="value" value="">
+            <input data-tag="inbound" style="text-align:center" id="value" type="number" min="-100000" max="100000" name="value" value="">
             <input type="hidden" name="key" value="ALL-iRate">
           </form>
         </td>
         <td title="Update all channel inbound base fees">
           <form action="/update_setting/" method="post">
             {% csrf_token %}
-            <input data-tag="inbound" style="text-align:center" id="value" type="number" min="-100000000" max="0" name="value" value="">
+            <input data-tag="inbound" style="text-align:center" id="value" type="number" min="-100000000" max="100000000" name="value" value="">
             <input type="hidden" name="key" value="ALL-iBase">
           </form>
         </td>
@@ -157,7 +157,7 @@
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% elif channel.private == True %}style="background-color: rgba(110,118,129,0.4)"{% endif %}>
           <form action="/update_channel/" method="post">
             {% csrf_token %}
-            <input data-tag="inbound" style="text-align:center" id="target" type="number" min="-100000" max="0" name="target" value="{{ channel.local_inbound_fee_rate }}">
+            <input data-tag="inbound" style="text-align:center" id="target" type="number" min="-100000" max="100000" name="target" value="{{ channel.local_inbound_fee_rate }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
             <input type="hidden" name="update_target" value="13">
           </form>
@@ -165,7 +165,7 @@
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% elif channel.private == True %}style="background-color: rgba(110,118,129,0.4)"{% endif %}>
           <form action="/update_channel/" method="post">
             {% csrf_token %}
-            <input data-tag="inbound" style="text-align:center" id="target" type="number" min="-100000000" max="0" name="target" value="{{ channel.local_inbound_base_fee }}">
+            <input data-tag="inbound" style="text-align:center" id="target" type="number" min="-100000000" max="100000000" name="target" value="{{ channel.local_inbound_base_fee }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
             <input type="hidden" name="update_target" value="12">
           </form>

--- a/gui/templates/fee_rates.html
+++ b/gui/templates/fee_rates.html
@@ -67,7 +67,7 @@
         <td>
           <form action="/update_channel/" method="post">
             {% csrf_token %}
-            <input style="text-align:center" id="target" type="number" min="-100000" max="0" name="target" value="{{ channel.local_inbound_fee_rate }}">
+            <input style="text-align:center" id="target" type="number" min="-100000" max="100000" name="target" value="{{ channel.local_inbound_fee_rate }}">
             <input type="hidden" name="chan_id" value="{{ channel.chan_id }}">
             <input type="hidden" name="update_target" value="13">
           </form>


### PR DESCRIPTION
## Summary
- allow positive inbound rate values on advanced and fee rate pages by expanding input limits
- extend inbound base fee inputs to accept positive numbers to match updated behavior