### PR TITLE
Add failed HTLC boost auto-fee setting

### DIFF
--- a/af.py
+++ b/af.py
@@ -37,6 +37,7 @@ def main(channels):
     increment = get_local_setting('AF-Increment', 5, int)
     multiplier = get_local_setting('AF-Multiplier', 5, int)
     failed_htlc_limit = get_local_setting('AF-FailedHTLCs', 25, int)
+    failed_htlc_boost = get_local_setting('AF-FailedHTLCBoost', 0, int)
     update_hours = get_local_setting('AF-UpdateHours', 24.0, float)
     lowliq_limit = get_local_setting('AF-LowLiqLimit', 5, int)
     excess_limit = get_local_setting('AF-ExcessLimit', 95, int)
@@ -341,6 +342,16 @@ def main(channels):
     channels_df['new_rate'] = channels_df['local_fee_rate'] + channels_df['adjustment']
     channels_df['new_rate'] = (channels_df['new_rate'] / increment).round(0) * increment
     channels_df['new_rate'] = channels_df['new_rate'].clip(min_rate, max_rate)
+    if failed_htlc_boost > 0:
+        failure_mask = (
+            (channels_df['overall_out_percent'] <= lowliq_limit)
+            & (channels_df['total_failed_out_1day'] > failed_htlc_limit)
+            & (channels_df['total_amt_routed_in_1day'] == 0)
+        )
+        if failure_mask.any():
+            channels_df.loc[failure_mask, 'new_rate'] = (
+                channels_df.loc[failure_mask, 'new_rate'] + failed_htlc_boost
+            ).clip(lower=min_rate, upper=max_rate)
     def compute_cost_floor(row):
         if not flp_enabled_global:
             return 0

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -62,6 +62,7 @@ class AutoFeesForm(AutoRebalanceForm):
     af_flow_scale = forms.FloatField(label='af_flow_scale', required=False)
     af_maxstep = forms.IntegerField(label='af_maxstep', required=False)
     af_failedHTLCs = forms.IntegerField(label='af_failedHTLCs', required=False)
+    af_failedhtlcboost = forms.IntegerField(label='af_failedhtlcboost', required=False)
     af_updateHours = forms.FloatField(label='af_updateHours', required=False)
     af_lowliq = forms.IntegerField(label='af_lowliq', required=False)
     af_lowliqboost = forms.FloatField(label='af_lowliqboost', required=False)

--- a/gui/views.py
+++ b/gui/views.py
@@ -2563,6 +2563,7 @@ def get_local_settings(*prefixes):
         form.append({'unit': 'x', 'form_id': 'af_flow_scale', 'value': 1.0, 'label': 'Flow Scale', 'id': 'AF-FlowScale', 'title': 'Scale flow-based adjustments; 0 disables flow factor', 'min':0})
         form.append({'unit': 'ppm', 'form_id': 'af_maxstep', 'value': 100, 'label': 'Max Step', 'id': 'AF-MaxStep', 'title': 'Maximum change allowed per update', 'min':1})
         form.append({'unit': '', 'form_id': 'af_failedHTLCs', 'value': 25, 'label': 'AF FailedHTLCs', 'id': 'AF-FailedHTLCs', 'title': 'Failed HTLCs required since last fee update to trigger a fee increase (when chan liq% is below AR-LowLiq). Default 25', 'min':1, 'max':100})
+        form.append({'unit': 'ppm', 'form_id': 'af_failedhtlcboost', 'value': 0, 'label': 'Failed HTLC Boost', 'id': 'AF-FailedHTLCBoost', 'title': 'Additional ppm added when failed HTLC low-liquidity trigger fires. Default 0', 'min':0})
         form.append({'unit': 'hours', 'form_id': 'af_updateHours', 'value': 24, 'label': 'AF Update', 'id': 'AF-UpdateHours', 'title': 'Minimum number of hours between fee updates for an individual channel. Default 24', 'min':0.01, 'max':100})
         form.append({'unit': '%', 'form_id': 'af_lowliq', 'value': 15, 'label': 'AF LowLiq', 'id': 'AF-LowLiqLimit', 'title': 'Limit for running low liq AF rules (increase when failed htlcs + no inbound). Default 15', 'min':0, 'max':100})
         form.append({'unit': 'x', 'form_id': 'af_lowliqboost', 'value': 1, 'label': 'AF LowLiq Boost', 'id': 'AF-LowLiqBoost', 'title': 'Multiplier for extra fee bump when liquidity is below AF-LowLiqLimit. Default 1', 'min':0, 'max':10})
@@ -2642,7 +2643,8 @@ def update_settings(request):
                      {'form_id': 'af_multiplier', 'value': 5, 'parse': lambda x: int(x),'id': 'AF-Multiplier'},
                      {'form_id': 'af_flow_scale', 'value': 1.0, 'parse': lambda x: float(x),'id': 'AF-FlowScale'},
                      {'form_id': 'af_maxstep', 'value': 100, 'parse': lambda x: int(x),'id': 'AF-MaxStep'},
-                     {'form_id': 'af_failedHTLCs', 'value': 25, 'parse': lambda x: int(x),'id': 'AF-FailedHTLCs'},
+                    {'form_id': 'af_failedHTLCs', 'value': 25, 'parse': lambda x: int(x),'id': 'AF-FailedHTLCs'},
+                    {'form_id': 'af_failedhtlcboost', 'value': 0, 'parse': lambda x: int(x),'id': 'AF-FailedHTLCBoost'},
                     {'form_id': 'af_updateHours', 'value': 24, 'parse': lambda x: float(x),'id': 'AF-UpdateHours'},
                     {'form_id': 'af_lowliq', 'value': 15, 'parse': lambda x: int(x),'id': 'AF-LowLiqLimit'},
                     {'form_id': 'af_lowliqboost', 'value': 1, 'parse': lambda x: float(x),'id': 'AF-LowLiqBoost'},


### PR DESCRIPTION
## Summary
- add a configurable Failed HTLC Boost setting to the auto-fee configuration UI
- plumb the new value through Django forms and settings persistence
- apply the configured boost when the low-liquidity failed HTLC condition triggers in autofee calculations
